### PR TITLE
Expand biome options and unify inventory store

### DIFF
--- a/src/biomes.js
+++ b/src/biomes.js
@@ -2,7 +2,10 @@ export const biomes = [
   { id: 'desert', name: 'Desert', features: ['dunes', 'oasis', 'mesa'], woodMod: 0.2 },
   { id: 'taiga', name: 'Taiga', features: ['pine forest', 'bog', 'hills'], woodMod: 1.0 },
   { id: 'tundra', name: 'Tundra', features: ['permafrost', 'ice field', 'rocky plain'], woodMod: 0.5 },
-  { id: 'plains', name: 'Plains', features: ['grassland', 'river', 'cliff'], woodMod: 0.8 }
+  { id: 'plains', name: 'Plains', features: ['grassland', 'river', 'cliff'], woodMod: 0.8 },
+  { id: 'tropical-rainforest', name: 'Tropical Rainforest', features: ['dense jungle', 'river', 'rolling hills'], woodMod: 1.2 },
+  { id: 'temperate-rainforest', name: 'Temperate Rainforest', features: ['wet forest', 'coastal cliffs', 'mossy ground'], woodMod: 1.1 },
+  { id: 'boreal-forest', name: 'Boreal Forest', features: ['conifer forest', 'lakes', 'bog'], woodMod: 0.9 }
 ];
 
 export function getBiome(id) {

--- a/src/inventory.js
+++ b/src/inventory.js
@@ -1,17 +1,25 @@
 import store from './state.js';
 
+function upsert(record) {
+  if (store.getItem('inventory', record.id)) {
+    store.updateItem('inventory', record);
+  } else {
+    store.addItem('inventory', record);
+  }
+}
+
 export function addItem(name, quantity = 0) {
-  const record = store.inventory.get(name) || { quantity: 0, demand: 0 };
+  const record = store.getItem('inventory', name) || { id: name, quantity: 0, demand: 0 };
   record.quantity += quantity;
-  store.inventory.set(name, record);
+  upsert(record);
 }
 
 export function adjustDemand(name, amount) {
-  const record = store.inventory.get(name) || { quantity: 0, demand: 0 };
+  const record = store.getItem('inventory', name) || { id: name, quantity: 0, demand: 0 };
   record.demand += amount;
-  store.inventory.set(name, record);
+  upsert(record);
 }
 
 export function getItem(name) {
-  return store.inventory.get(name) || { quantity: 0, demand: 0 };
+  return store.getItem('inventory', name) || { quantity: 0, demand: 0 };
 }


### PR DESCRIPTION
## Summary
- add tropical, temperate and boreal forests to biome list so setup UI exposes seven options
- refactor inventory helpers to reuse core DataStore add/update mechanisms

## Testing
- `npm test`
- `node -e "import('./src/biomes.js').then(m=>console.log(m.biomes.length))"`


------
https://chatgpt.com/codex/tasks/task_e_689568db8db88325abe44d255948f676