### PR TITLE
Expand and unify biome list

### DIFF
--- a/src/biomes.js
+++ b/src/biomes.js
@@ -1,91 +1,114 @@
-const coreBiomes = [
+export const biomes = [
   {
-    id: 'desert',
-    name: 'Desert',
-    features: ['dunes', 'oasis', 'mesa'],
-    woodMod: 0.2
+    id: 'alpine',
+    name: 'Alpine',
+    features: ['snow-capped peaks', 'glacial valley', 'rocky slopes'],
+    woodMod: 0.3,
+    description: 'High mountains where trees are sparse and the air is thin.'
   },
   {
-    id: 'taiga',
-    name: 'Taiga',
-    features: ['pine forest', 'bog', 'hills'],
-    woodMod: 1.0
+    id: 'boreal-taiga',
+    name: 'Boreal (Taiga)',
+    features: ['conifer forest', 'bog', 'cold rivers'],
+    woodMod: 1.0,
+    description: 'Cold northern forests dominated by pines and dotted with bogs.'
   },
   {
-    id: 'tundra',
-    name: 'Tundra',
-    features: ['permafrost', 'ice field', 'rocky plain'],
-    woodMod: 0.5
+    id: 'coastal-temperate',
+    name: 'Coastal (Temperate)',
+    features: ['rocky shore', 'tide pools', 'windy cliffs'],
+    woodMod: 0.8,
+    description: 'Cool coasts with rocky beaches and windswept cliffs.'
   },
   {
-    id: 'plains',
-    name: 'Plains',
-    features: ['grassland', 'river', 'cliff'],
-    woodMod: 0.8
+    id: 'coastal-tropical',
+    name: 'Coastal (Tropical)',
+    features: ['sandy beaches', 'coral reefs', 'lagoon'],
+    woodMod: 0.9,
+    description: 'Warm shores of sand and reef washed by gentle tropical seas.'
   },
   {
-    id: 'tropical-rainforest',
-    name: 'Tropical Rainforest',
-    features: ['dense jungle', 'river', 'rolling hills'],
-    woodMod: 1.2
+    id: 'flooded-grasslands',
+    name: 'Flooded Grasslands / Swamp',
+    features: ['marsh', 'reed beds', 'shallow lakes'],
+    woodMod: 0.7,
+    description: 'Waterlogged plains filled with reeds, marshes and standing water.'
+  },
+  {
+    id: 'island-temperate',
+    name: 'Island (Temperate)',
+    features: ['pebble beach', 'forest interior', 'cliffs'],
+    woodMod: 0.8,
+    description: 'A temperate island with forests, cliffs and cool seas.'
+  },
+  {
+    id: 'island-tropical',
+    name: 'Island (Tropical)',
+    features: ['palm beach', 'volcanic ridge', 'lagoon'],
+    woodMod: 0.9,
+    description: 'Lush tropical islands fringed by palms and volcanic heights.'
+  },
+  {
+    id: 'mangrove',
+    name: 'Mangrove',
+    features: ['mangrove forest', 'brackish water', 'mudflats'],
+    woodMod: 1.0,
+    description: 'Dense coastal forests rooted in tidal mud and brackish water.'
+  },
+  {
+    id: 'mediterranean-woodland',
+    name: 'Mediterranean Woodland',
+    features: ['scrubland', 'olive groves', 'rocky hills'],
+    woodMod: 0.9,
+    description: 'Warm dry woodlands with scrub and hardy trees.'
+  },
+  {
+    id: 'montane-cloud',
+    name: 'Montane / Cloud',
+    features: ['misty forest', 'steep terrain', 'waterfalls'],
+    woodMod: 0.8,
+    description: 'High elevation forests perpetually shrouded in mist.'
+  },
+  {
+    id: 'savanna',
+    name: 'Savanna',
+    features: ['grassland', 'acacia trees', 'watering hole'],
+    woodMod: 0.6,
+    description: 'Vast grassy plains dotted with trees and seasonal water.'
+  },
+  {
+    id: 'temperate-deciduous',
+    name: 'Temperate Deciduous',
+    features: ['broadleaf forest', 'meadow', 'stream'],
+    woodMod: 1.1,
+    description: 'Forests of broadleaf trees that change with the seasons.'
   },
   {
     id: 'temperate-rainforest',
     name: 'Temperate Rainforest',
     features: ['wet forest', 'coastal cliffs', 'mossy ground'],
-    woodMod: 1.1
+    woodMod: 1.1,
+    description: 'Mild coastal forests kept lush by constant rain and fog.'
   },
   {
-    id: 'boreal-forest',
-    name: 'Boreal Forest',
-    features: ['conifer forest', 'lakes', 'bog'],
-    woodMod: 0.9
-  }
-];
-
-const biomeDescriptions = [
-  {
-    id: 'desert',
-    description: 'A vast sandy landscape with dunes, sparse oases, and extreme temperatures.'
-  },
-  {
-    id: 'taiga',
-    description: 'Cold forests of pines and bogs stretching across the north.'
-  },
-  {
-    id: 'tundra',
-    description: 'Frozen, treeless plains with permafrost and icy winds.'
-  },
-  {
-    id: 'plains',
-    description: 'Open grasslands dotted with rivers and occasional cliffs.'
+    id: 'tropical-monsoon',
+    name: 'Tropical Monsoon',
+    features: ['seasonal forest', 'river delta', 'monsoon rains'],
+    woodMod: 1.0,
+    description: 'Tropical forests with distinct wet and dry seasons.'
   },
   {
     id: 'tropical-rainforest',
-    description: 'Dense, humid jungle teeming with life and rolling hills.'
-  },
-  {
-    id: 'temperate-rainforest',
-    description: 'Wet, mossy forests near coasts with towering trees.'
-  },
-  {
-    id: 'boreal-forest',
-    description: 'Coniferous woodland interspersed with lakes and boggy ground.'
+    name: 'Tropical Rainforest',
+    features: ['dense jungle', 'river', 'rolling hills'],
+    woodMod: 1.2,
+    description: 'Hot, humid jungles teeming with life and thick vegetation.'
   }
 ];
 
-// Merge datasets and remove duplicates by biome id
-const biomeMap = new Map();
-[...coreBiomes, ...biomeDescriptions].forEach(b => {
-  if (biomeMap.has(b.id)) {
-    Object.assign(biomeMap.get(b.id), b);
-  } else {
-    biomeMap.set(b.id, { ...b });
-  }
-});
-
-export const biomes = Array.from(biomeMap.values());
+const biomeMap = new Map(biomes.map(b => [b.id, b]));
 
 export function getBiome(id) {
   return biomeMap.get(id);
 }
+

--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,7 @@ function startGame(settings = {}) {
   if (settings.biome) {
     generateLocation('loc1', settings.biome);
   } else if (store.locations.size === 0) {
-    generateLocation('loc1', 'plains');
+    generateLocation('loc1', 'temperate-deciduous');
   }
   shelterTypes.forEach(registerBuildingType);
   unlockTechnology({ id: 'basic-tools', name: 'Basic Tools' });
@@ -28,7 +28,7 @@ function startGame(settings = {}) {
 
   // Simple example of resource production influenced by tech/location.
   const loc = [...store.locations.values()][0];
-  const wood = harvestWood(1, loc?.biome || 'plains');
+  const wood = harvestWood(1, loc?.biome || 'temperate-deciduous');
   addItem('wood', wood);
 
   advanceDay();

--- a/src/resources.js
+++ b/src/resources.js
@@ -20,7 +20,7 @@ const woodYieldPerDay = {
  * @param {string} biome - current location biome
  * @returns {number} pounds of wood harvested per day
  */
-export function harvestWood(workers = 0, biome = 'plains') {
+export function harvestWood(workers = 0, biome = 'temperate-deciduous') {
   let tech = 'stone-hand-axe';
   if (hasTechnology('bronze-tools')) tech = 'bronze-axe';
   if (hasTechnology('iron-tools')) tech = 'iron-axe';


### PR DESCRIPTION
## Summary
- replace scattered biome data with single consolidated list
- support 15 starting biomes including alpine, mangrove, and savanna
- default game start and wood harvest to temperate deciduous biome

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689675e1111483258ed6f4022608d541