### PR TITLE
Display biome and difficulty details in setup UI

### DIFF
--- a/src/biomes.js
+++ b/src/biomes.js
@@ -4,6 +4,8 @@ export const biomes = [
     name: 'Alpine',
     features: ['snow-capped peaks', 'glacial valley', 'rocky slopes'],
     woodMod: 0.3,
+    openLand: 0.2,
+    food: 0.2,
     description: 'High mountains where trees are sparse and the air is thin.'
   },
   {
@@ -11,6 +13,8 @@ export const biomes = [
     name: 'Boreal (Taiga)',
     features: ['conifer forest', 'bog', 'cold rivers'],
     woodMod: 1.0,
+    openLand: 0.3,
+    food: 0.4,
     description: 'Cold northern forests dominated by pines and dotted with bogs.'
   },
   {
@@ -18,6 +22,8 @@ export const biomes = [
     name: 'Coastal (Temperate)',
     features: ['rocky shore', 'tide pools', 'windy cliffs'],
     woodMod: 0.8,
+    openLand: 0.5,
+    food: 0.6,
     description: 'Cool coasts with rocky beaches and windswept cliffs.'
   },
   {
@@ -25,6 +31,8 @@ export const biomes = [
     name: 'Coastal (Tropical)',
     features: ['sandy beaches', 'coral reefs', 'lagoon'],
     woodMod: 0.9,
+    openLand: 0.5,
+    food: 0.9,
     description: 'Warm shores of sand and reef washed by gentle tropical seas.'
   },
   {
@@ -32,6 +40,8 @@ export const biomes = [
     name: 'Flooded Grasslands / Swamp',
     features: ['marsh', 'reed beds', 'shallow lakes'],
     woodMod: 0.7,
+    openLand: 0.4,
+    food: 0.6,
     description: 'Waterlogged plains filled with reeds, marshes and standing water.'
   },
   {
@@ -39,6 +49,8 @@ export const biomes = [
     name: 'Island (Temperate)',
     features: ['pebble beach', 'forest interior', 'cliffs'],
     woodMod: 0.8,
+    openLand: 0.5,
+    food: 0.7,
     description: 'A temperate island with forests, cliffs and cool seas.'
   },
   {
@@ -46,6 +58,8 @@ export const biomes = [
     name: 'Island (Tropical)',
     features: ['palm beach', 'volcanic ridge', 'lagoon'],
     woodMod: 0.9,
+    openLand: 0.5,
+    food: 0.9,
     description: 'Lush tropical islands fringed by palms and volcanic heights.'
   },
   {
@@ -53,6 +67,8 @@ export const biomes = [
     name: 'Mangrove',
     features: ['mangrove forest', 'brackish water', 'mudflats'],
     woodMod: 1.0,
+    openLand: 0.3,
+    food: 0.8,
     description: 'Dense coastal forests rooted in tidal mud and brackish water.'
   },
   {
@@ -60,6 +76,8 @@ export const biomes = [
     name: 'Mediterranean Woodland',
     features: ['scrubland', 'olive groves', 'rocky hills'],
     woodMod: 0.9,
+    openLand: 0.6,
+    food: 0.7,
     description: 'Warm dry woodlands with scrub and hardy trees.'
   },
   {
@@ -67,6 +85,8 @@ export const biomes = [
     name: 'Montane / Cloud',
     features: ['misty forest', 'steep terrain', 'waterfalls'],
     woodMod: 0.8,
+    openLand: 0.3,
+    food: 0.5,
     description: 'High elevation forests perpetually shrouded in mist.'
   },
   {
@@ -74,6 +94,8 @@ export const biomes = [
     name: 'Savanna',
     features: ['grassland', 'acacia trees', 'watering hole'],
     woodMod: 0.6,
+    openLand: 0.8,
+    food: 0.5,
     description: 'Vast grassy plains dotted with trees and seasonal water.'
   },
   {
@@ -81,6 +103,8 @@ export const biomes = [
     name: 'Temperate Deciduous',
     features: ['broadleaf forest', 'meadow', 'stream'],
     woodMod: 1.1,
+    openLand: 0.6,
+    food: 0.7,
     description: 'Forests of broadleaf trees that change with the seasons.'
   },
   {
@@ -88,6 +112,8 @@ export const biomes = [
     name: 'Temperate Rainforest',
     features: ['wet forest', 'coastal cliffs', 'mossy ground'],
     woodMod: 1.1,
+    openLand: 0.4,
+    food: 0.8,
     description: 'Mild coastal forests kept lush by constant rain and fog.'
   },
   {
@@ -95,6 +121,8 @@ export const biomes = [
     name: 'Tropical Monsoon',
     features: ['seasonal forest', 'river delta', 'monsoon rains'],
     woodMod: 1.0,
+    openLand: 0.5,
+    food: 1.0,
     description: 'Tropical forests with distinct wet and dry seasons.'
   },
   {
@@ -102,6 +130,8 @@ export const biomes = [
     name: 'Tropical Rainforest',
     features: ['dense jungle', 'river', 'rolling hills'],
     woodMod: 1.2,
+    openLand: 0.3,
+    food: 1.2,
     description: 'Hot, humid jungles teeming with life and thick vegetation.'
   }
 ];

--- a/src/difficulty.js
+++ b/src/difficulty.js
@@ -1,0 +1,36 @@
+export const difficulties = [
+  { id: 'easy', name: 'Easy' },
+  { id: 'normal', name: 'Medium' },
+  { id: 'hard', name: 'Hard' }
+];
+
+export const difficultySettings = {
+  easy: {
+    people: 9,
+    foodDays: 7,
+    firewoodDays: 7,
+    tools: {
+      'stone hand axe': 1,
+      'stone knife': 1,
+      bow: 1,
+      'wooden arrow': 10,
+      'wooden shovel': 1,
+      'wooden hammer': 1
+    }
+  },
+  normal: {
+    people: 7,
+    foodDays: 3,
+    firewoodDays: 3,
+    tools: {
+      'stone hand axe': 1,
+      'stone knife': 1
+    }
+  },
+  hard: {
+    people: 5,
+    foodDays: 0,
+    firewoodDays: 0,
+    tools: {}
+  }
+};

--- a/src/main.js
+++ b/src/main.js
@@ -9,12 +9,22 @@ import { harvestWood } from './resources.js';
 import { initSetupUI } from './ui.js';
 import { saveGame, loadGame } from './persistence.js';
 import { shelterTypes } from './shelters.js';
+import { difficultySettings } from './difficulty.js';
 
 function startGame(settings = {}) {
-  if (!store.people.size) {
-    addPerson({ id: 'p1', age: 30, sex: 'M', job: 'lumberjack', home: null, family: [] });
+  const diff = settings.difficulty || 'normal';
+  const cfg = difficultySettings[diff];
+
+  for (let i = 1; i <= cfg.people; i++) {
+    addPerson({ id: `p${i}`, age: 20 + i, sex: i % 2 ? 'M' : 'F', job: null, home: null, family: [] });
   }
-  addItem('food', 100);
+
+  const foodPerPersonPerDay = 1;
+  addItem('food', cfg.people * cfg.foodDays * foodPerPersonPerDay);
+  addItem('firewood', cfg.people * cfg.firewoodDays);
+
+  Object.entries(cfg.tools).forEach(([item, qty]) => addItem(item, qty));
+
   if (settings.biome) {
     generateLocation('loc1', settings.biome);
   } else if (store.locations.size === 0) {
@@ -24,7 +34,7 @@ function startGame(settings = {}) {
   unlockTechnology({ id: 'basic-tools', name: 'Basic Tools' });
 
   if (settings.season) store.time.season = settings.season;
-  if (settings.difficulty) store.difficulty = settings.difficulty;
+  store.difficulty = diff;
 
   // Simple example of resource production influenced by tech/location.
   const loc = [...store.locations.values()][0];
@@ -46,6 +56,7 @@ function render() {
     people: peopleStats(),
     inventory: {
       food: getItem('food'),
+      firewood: getItem('firewood'),
       wood: getItem('wood')
     },
     time: timeInfo(),

--- a/src/ui.js
+++ b/src/ui.js
@@ -4,14 +4,9 @@
 // without affecting the rest of the game logic.
 
 import { biomes } from './biomes.js';
+import { difficulties, difficultySettings } from './difficulty.js';
 
 const seasons = ['Spring', 'Summer', 'Autumn', 'Winter'];
-
-const difficulties = [
-  { id: 'easy', name: 'Easy' },
-  { id: 'normal', name: 'Normal' },
-  { id: 'hard', name: 'Hard' }
-];
 
 /**
  * Create a temporary setup form and call the provided callback when submitted.
@@ -49,10 +44,41 @@ export function initSetupUI(onStart) {
     form.appendChild(document.createElement('br'));
   });
 
+  const biomeInfo = document.createElement('p');
+  const diffInfo = document.createElement('p');
+  form.appendChild(biomeInfo);
+  form.appendChild(diffInfo);
+
   const startBtn = document.createElement('button');
   startBtn.type = 'submit';
   startBtn.textContent = 'Start';
   form.appendChild(startBtn);
+
+  const formatDays = d => (d >= 7 ? `${d / 7} week${d >= 14 ? 's' : ''}` : `${d} day${d !== 1 ? 's' : ''}`);
+
+  const updateBiomeInfo = () => {
+    const b = biomes.find(x => x.id === biomeSelect.select.value);
+    if (!b) {
+      biomeInfo.textContent = '';
+      return;
+    }
+    biomeInfo.innerHTML = `<strong>${b.name}</strong>: ${b.description}<br>Open land: ${b.openLand}<br>Food resources: ${b.food}`;
+  };
+
+  const updateDiffInfo = () => {
+    const id = diffSelect.select.value;
+    const cfg = difficultySettings[id];
+    const name = diffSelect.select.options[diffSelect.select.selectedIndex].textContent;
+    const tools = Object.entries(cfg.tools)
+      .map(([t, q]) => `${q} ${t}`)
+      .join(', ') || 'None';
+    diffInfo.innerHTML = `<strong>Difficulty:</strong> ${name}<br>Starting people: ${cfg.people}<br>Food: ${formatDays(cfg.foodDays)} stock<br>Firewood: ${formatDays(cfg.firewoodDays)} stock<br>Tools: ${tools}`;
+  };
+
+  biomeSelect.select.addEventListener('change', updateBiomeInfo);
+  diffSelect.select.addEventListener('change', updateDiffInfo);
+  updateBiomeInfo();
+  updateDiffInfo();
 
   form.addEventListener('submit', e => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Extend biome data with open land and food availability metrics
- Show selected biome details and difficulty-based starting resources in setup UI
- Initialize people, supplies, and tools according to chosen difficulty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689690e317e48325a72251e7cf8a10aa