### PR TITLE
Add basic game interface with job assignments

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <body>
   <h1>Fantasy Survival</h1>
   <div id="setup"></div>
-  <pre id="output"></pre>
+  <div id="game" style="display:none;"></div>
   <script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -1,0 +1,109 @@
+import { stats as peopleStats } from './people.js';
+import { getItem, addItem } from './inventory.js';
+import { advanceDay, info as timeInfo } from './time.js';
+import { getJobs, setJob } from './jobs.js';
+import store from './state.js';
+
+function computeChanges() {
+  const adults = peopleStats().total;
+  const jobs = getJobs();
+  let laborers = jobs.laborer || 0;
+
+  // Prioritize building then hauling
+  const buildingTasks = store.buildQueue || 0;
+  const haulingTasks = store.haulQueue || 0;
+
+  const buildingWorkers = Math.min(laborers, buildingTasks);
+  laborers -= buildingWorkers;
+  const haulingWorkers = Math.min(laborers, haulingTasks);
+  laborers -= haulingWorkers;
+
+  // Remaining laborers gather firewood and food evenly
+  const firewoodWorkers = Math.floor(laborers / 2);
+  const foodWorkers = laborers - firewoodWorkers;
+
+  return {
+    food: { quantity: getItem('food').quantity, supply: foodWorkers, demand: adults },
+    firewood: { quantity: getItem('firewood').quantity, supply: firewoodWorkers, demand: adults }
+  };
+}
+
+function render() {
+  const container = document.getElementById('game');
+  if (!container) return;
+
+  const t = timeInfo();
+  const turn = container.querySelector('#turn');
+  if (turn) turn.textContent = `Day ${t.day} - ${t.season}`;
+
+  const changes = computeChanges();
+  const inv = container.querySelector('#inventory');
+  if (inv) {
+    inv.innerHTML = '<h3>Inventory</h3>';
+    const table = document.createElement('table');
+    const header = document.createElement('tr');
+    header.innerHTML = '<th>Item</th><th>Qty</th><th>Δ/turn</th>';
+    table.appendChild(header);
+    Object.entries(changes).forEach(([name, data]) => {
+      const tr = document.createElement('tr');
+      const net = data.supply - data.demand;
+      tr.innerHTML = `<td>${name}</td><td>${data.quantity}</td><td>${net}</td>`;
+      table.appendChild(tr);
+    });
+    inv.appendChild(table);
+  }
+}
+
+function processTurn() {
+  const changes = computeChanges();
+  Object.entries(changes).forEach(([name, data]) => {
+    const net = data.supply - data.demand;
+    addItem(name, net);
+  });
+  advanceDay();
+  render();
+}
+
+function showJobs() {
+  const adults = peopleStats().total;
+  const jobs = getJobs();
+  const current = jobs.laborer || 0;
+  const input = prompt(`Assign laborers (0-${adults})`, current);
+  const num = parseInt(input, 10);
+  if (!isNaN(num)) {
+    setJob('laborer', num);
+    render();
+  }
+}
+
+export function initGameUI() {
+  const container = document.getElementById('game');
+  if (!container) return;
+  container.innerHTML = '';
+
+  const turn = document.createElement('div');
+  turn.id = 'turn';
+
+  const next = document.createElement('button');
+  next.textContent = 'Next Turn';
+  next.addEventListener('click', processTurn);
+
+  const jobsBtn = document.createElement('button');
+  jobsBtn.textContent = 'Jobs';
+  jobsBtn.addEventListener('click', showJobs);
+
+  const inv = document.createElement('div');
+  inv.id = 'inventory';
+
+  container.appendChild(turn);
+  container.appendChild(next);
+  container.appendChild(jobsBtn);
+  container.appendChild(inv);
+
+  container.style.display = 'block';
+  render();
+}
+
+export function updateGameUI() {
+  render();
+}

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -1,0 +1,26 @@
+import store from './state.js';
+import { stats as peopleStats } from './people.js';
+
+function ensureJobs() {
+  if (!store.jobs) store.jobs = { laborer: 0 };
+}
+
+export function getJobs() {
+  ensureJobs();
+  return { ...store.jobs };
+}
+
+export function setJob(name, count) {
+  ensureJobs();
+  const adults = peopleStats().total;
+  const others = Object.entries(store.jobs)
+    .filter(([k]) => k !== name)
+    .reduce((sum, [, v]) => sum + v, 0);
+  const max = Math.max(0, adults - others);
+  store.jobs[name] = Math.max(0, Math.min(count, max));
+}
+
+export function totalAssigned() {
+  ensureJobs();
+  return Object.values(store.jobs).reduce((a, b) => a + b, 0);
+}


### PR DESCRIPTION
## Summary
- Add a dedicated game view with turn counter, next turn control, inventory display and job allocation dialog
- Track laborer assignments and per-turn supply/demand to compute inventory changes
- Limit job assignments to the available adult population

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896bc787550832590dc3c64608b58cf