### PR TITLE
Fix game UI initialization timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -49,12 +49,20 @@ function startGame(settings = {}) {
   initGameUI();
 }
 
-if (!loadGame()) {
-  initSetupUI(startGame);
+function init() {
+  if (!loadGame()) {
+    initSetupUI(startGame);
+  } else {
+    const setupDiv = document.getElementById('setup');
+    if (setupDiv) setupDiv.style.display = 'none';
+    initGameUI();
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
 } else {
-  const setupDiv = document.getElementById('setup');
-  if (setupDiv) setupDiv.style.display = 'none';
-  initGameUI();
+  init();
 }
 
 window.Game = { store, saveGame };


### PR DESCRIPTION
## Summary
- Ensure the game UI initializes only after the DOM is fully loaded
- Wrap game startup logic in an `init` function that waits for `DOMContentLoaded`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896c0f80fd483258e6ff7de52b4f7f6