### PR TITLE
feat: add jobs popup and default laborers

### DIFF
--- a/src/jobs.js
+++ b/src/jobs.js
@@ -2,17 +2,21 @@ import store from './state.js';
 import { stats as peopleStats } from './people.js';
 
 function ensureJobs() {
-  if (!store.jobs) store.jobs = { laborer: 0 };
+  if (!store.jobs) store.jobs = {};
 }
 
 export function getJobs() {
   ensureJobs();
-  return { ...store.jobs };
+  const adults = peopleStats().adults || 0;
+  const assigned = Object.values(store.jobs).reduce((a, b) => a + b, 0);
+  const laborer = Math.max(0, adults - assigned);
+  return { ...store.jobs, laborer };
 }
 
 export function setJob(name, count) {
   ensureJobs();
-  const adults = peopleStats().total;
+  if (name === 'laborer') return;
+  const adults = peopleStats().adults || 0;
   const others = Object.entries(store.jobs)
     .filter(([k]) => k !== name)
     .reduce((sum, [, v]) => sum + v, 0);

--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,7 @@ function startGame(settings = {}) {
 
   if (settings.season) store.time.season = settings.season;
   store.difficulty = diff;
-  store.jobs = { laborer: 0 };
+  store.jobs = {};
   store.buildQueue = 0;
   store.haulQueue = 0;
 

--- a/src/people.js
+++ b/src/people.js
@@ -13,13 +13,25 @@ export function updatePerson(person) {
 function updateGlobals() {
   const people = [...store.people.values()];
   const total = people.length;
+  const adults = people.filter(p => (p.age ?? 0) >= 16).length;
+  const children = total - adults;
   const employed = people.filter(p => p.job).length;
   const unemployed = total - employed;
   const housed = people.filter(p => p.home).length;
   const homeless = total - housed;
-  store.peopleStats = { total, employed, unemployed, housed, homeless };
+  store.peopleStats = { total, adults, children, employed, unemployed, housed, homeless };
 }
 
 export function stats() {
-  return store.peopleStats || { total: 0, employed: 0, unemployed: 0, housed: 0, homeless: 0 };
+  return (
+    store.peopleStats || {
+      total: 0,
+      adults: 0,
+      children: 0,
+      employed: 0,
+      unemployed: 0,
+      housed: 0,
+      homeless: 0
+    }
+  );
 }


### PR DESCRIPTION
## Summary
- count adults and children separately in people stats
- treat unassigned adults as laborers by default
- replace laborer prompt with jobs popup that lists population and job assignments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689753a94a8c8325b09080a99db2b930