### PR TITLE
Persist job allocations and add top menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,12 @@
   <title>Fantasy Survival</title>
 </head>
 <body>
-  <h1>Fantasy Survival</h1>
-  <div id="setup"></div>
-  <div id="game" style="display:none;"></div>
+  <div id="top-menu"></div>
+  <div id="content" style="margin-top:40px;">
+    <h1>Fantasy Survival</h1>
+    <div id="setup"></div>
+    <div id="game" style="display:none;"></div>
+  </div>
   <script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -4,6 +4,7 @@ import { advanceDay, info as timeInfo } from './time.js';
 import { getJobs, setJob } from './jobs.js';
 import store from './state.js';
 import { scavengeResources } from './resources.js';
+import { showBackButton } from './menu.js';
 
 // Keep a reference to the scavenge count element so the display can
 // be refreshed whenever the UI rerenders.
@@ -96,11 +97,12 @@ function processTurn() {
 
 let jobsPopup = null;
 
-function closeJobs() {
+export function closeJobs() {
   if (jobsPopup) {
     jobsPopup.remove();
     jobsPopup = null;
   }
+  showBackButton(false);
 }
 
 function renderJobs() {
@@ -178,7 +180,8 @@ function renderJobs() {
   document.body.appendChild(jobsPopup);
 }
 
-function showJobs() {
+export function showJobs() {
+  showBackButton(true);
   renderJobs();
 }
 
@@ -220,17 +223,12 @@ export function initGameUI() {
   scavengeRow.appendChild(scavengeDisplay);
   scavengeRow.appendChild(scavengeUp);
 
-  const jobsBtn = document.createElement('button');
-  jobsBtn.textContent = 'Jobs';
-  jobsBtn.addEventListener('click', showJobs);
-
   const inv = document.createElement('div');
   inv.id = 'inventory';
 
   container.appendChild(turn);
   container.appendChild(next);
   container.appendChild(scavengeRow);
-  container.appendChild(jobsBtn);
   container.appendChild(inv);
 
   container.style.display = 'block';

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -1,5 +1,6 @@
 import store from './state.js';
 import { stats as peopleStats } from './people.js';
+import { saveGame } from './persistence.js';
 
 function ensureJobs() {
   if (!store.jobs) store.jobs = {};
@@ -22,6 +23,7 @@ export function setJob(name, count) {
     .reduce((sum, [, v]) => sum + v, 0);
   const max = Math.max(0, adults - others);
   store.jobs[name] = Math.max(0, Math.min(count, max));
+  saveGame();
 }
 
 export function totalAssigned() {

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,8 @@ import { initSetupUI } from './ui.js';
 import { saveGame, loadGame } from './persistence.js';
 import { shelterTypes } from './shelters.js';
 import { difficultySettings } from './difficulty.js';
-import { initGameUI } from './gameUI.js';
+import { initGameUI, showJobs, closeJobs } from './gameUI.js';
+import { initTopMenu } from './menu.js';
 
 function startGame(settings = {}) {
   const diff = settings.difficulty || 'normal';
@@ -51,6 +52,7 @@ function startGame(settings = {}) {
 }
 
 function init() {
+  initTopMenu(showJobs, closeJobs);
   if (!loadGame()) {
     initSetupUI(startGame);
   } else {

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,0 +1,77 @@
+let zoomLevel = 1;
+
+function applyZoom() {
+  const content = document.getElementById('content');
+  if (content) {
+    content.style.transform = `scale(${zoomLevel})`;
+    content.style.transformOrigin = 'top left';
+  }
+}
+
+export function showBackButton(show) {
+  const back = document.getElementById('back-btn');
+  const menu = document.getElementById('menu-btn');
+  if (back && menu) {
+    back.style.display = show ? 'inline-block' : 'none';
+    menu.style.display = show ? 'none' : 'inline-block';
+  }
+}
+
+export function initTopMenu(onMenu, onBack) {
+  const bar = document.getElementById('top-menu');
+  if (!bar) return;
+  bar.innerHTML = '';
+  Object.assign(bar.style, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    right: '0',
+    background: '#eee',
+    padding: '4px',
+    display: 'flex',
+    gap: '4px',
+    zIndex: '1000'
+  });
+
+  const zoomOut = document.createElement('button');
+  zoomOut.textContent = '-';
+  zoomOut.addEventListener('click', () => {
+    zoomLevel = Math.max(0.5, Math.round((zoomLevel - 0.1) * 10) / 10);
+    applyZoom();
+  });
+
+  const zoomIn = document.createElement('button');
+  zoomIn.textContent = '+';
+  zoomIn.addEventListener('click', () => {
+    zoomLevel = Math.min(2, Math.round((zoomLevel + 0.1) * 10) / 10);
+    applyZoom();
+  });
+
+  const menuBtn = document.createElement('button');
+  menuBtn.id = 'menu-btn';
+  menuBtn.textContent = 'Menu';
+  if (typeof onMenu === 'function') {
+    menuBtn.addEventListener('click', () => {
+      onMenu();
+      showBackButton(true);
+    });
+  }
+
+  const backBtn = document.createElement('button');
+  backBtn.id = 'back-btn';
+  backBtn.textContent = 'Back';
+  backBtn.style.display = 'none';
+  if (typeof onBack === 'function') {
+    backBtn.addEventListener('click', () => {
+      onBack();
+      showBackButton(false);
+    });
+  }
+
+  bar.appendChild(zoomOut);
+  bar.appendChild(zoomIn);
+  bar.appendChild(menuBtn);
+  bar.appendChild(backBtn);
+  applyZoom();
+}
+

--- a/src/resources.js
+++ b/src/resources.js
@@ -75,6 +75,9 @@ export function scavengeResources(workers = 0) {
       totals[r.name] += weight / r.weight;
     });
   }
+  SCAVENGE_RESOURCES.forEach(r => {
+    totals[r.name] = Math.round(totals[r.name]);
+  });
   return totals;
 }
 

--- a/src/state.js
+++ b/src/state.js
@@ -7,6 +7,7 @@ class DataStore {
     this.technologies = new Map();
     this.time = { day: 0, season: 'Spring' };
     this.difficulty = 'normal';
+    this.jobs = {};
   }
 
   addItem(collection, item) {
@@ -45,7 +46,8 @@ class DataStore {
       locations: [...this.locations.entries()],
       technologies: [...this.technologies.entries()],
       time: this.time,
-      difficulty: this.difficulty
+      difficulty: this.difficulty,
+      jobs: this.jobs
     };
   }
 
@@ -58,6 +60,7 @@ class DataStore {
     this.technologies = new Map(data.technologies || []);
     this.time = data.time || { day: 0, season: 'Spring' };
     this.difficulty = data.difficulty || 'normal';
+    this.jobs = data.jobs || {};
   }
 }
 


### PR DESCRIPTION
## Summary
- Persist job assignments by serializing jobs and saving on assignment
- Round scavenged resources to whole items
- Introduce a fixed top menu with zoom controls, Menu and Back navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68981c9e2e008325af31aeaa75b0c9b7