### PR TITLE
Add biome-specific points of interest generation

### DIFF
--- a/biomes.js
+++ b/biomes.js
@@ -1,4 +1,5 @@
 import { biomes, getBiome } from './src/biomes.js';
+import { getPointsOfInterest } from './src/pointsOfInterest.js';
 
 // DOM Elements
 const selector = document.getElementById('biomeSelector');
@@ -23,9 +24,11 @@ selector.addEventListener('change', () => {
     image.src = '';
     return;
   }
+  const pois = getPointsOfInterest(selector.value);
   output.innerHTML = `
     <h2>${biome.name}</h2>
     <p><strong>Features:</strong> ${biome.features.join(', ')}</p>
+    <p><strong>Points of Interest:</strong> ${pois.join(', ')}</p>
     <p><strong>Wood Modifier:</strong> ${biome.woodMod}</p>
   `;
   description.textContent = biome.description;

--- a/src/location.js
+++ b/src/location.js
@@ -1,9 +1,11 @@
 import store from './state.js';
 import { getBiome } from './biomes.js';
+import { generatePointsOfInterest } from './pointsOfInterest.js';
 
 export function generateLocation(id, biome) {
   const features = getBiome(biome)?.features || [];
-  const location = { id, biome, features };
+  const pointsOfInterest = generatePointsOfInterest(biome);
+  const location = { id, biome, features, pointsOfInterest };
   store.addItem('locations', location);
   return location;
 }

--- a/src/pointsOfInterest.js
+++ b/src/pointsOfInterest.js
@@ -1,0 +1,31 @@
+export const pointsOfInterestData = {
+  'alpine': ['glacial cave', 'frozen waterfall', 'mountain spring', 'rocky ravine'],
+  'boreal-taiga': ['ice cave', 'pine river', 'bog', 'spring-fed pond'],
+  'coastal-temperate': ['pebble beach', 'sea cave', 'river mouth', 'tidal pool'],
+  'coastal-tropical': ['sandy beach', 'coral lagoon', 'freshwater spring', 'sea cave'],
+  'flooded-grasslands': ['reed marsh', 'shallow lake', 'slow river', 'muddy spring'],
+  'island-temperate': ['rocky beach', 'cliff cave', 'forest spring', 'tidal pool'],
+  'island-tropical': ['palm beach', 'volcanic cave', 'jungle river', 'hidden lagoon'],
+  'mangrove': ['tidal creek', 'brackish lagoon', 'mudflat', 'freshwater spring'],
+  'mediterranean-woodland': ['limestone cave', 'rocky spring', 'seasonal river', 'stone ravine'],
+  'montane-cloud': ['misty waterfall', 'mountain spring', 'steep ravine', 'cloud forest cave'],
+  'savanna': ['watering hole', 'seasonal river', 'acacia grove', 'rocky outcrop cave'],
+  'temperate-deciduous': ['forest stream', 'limestone cave', 'spring-fed pond', 'river gorge'],
+  'temperate-rainforest': ['mossy waterfall', 'river gorge', 'cedar bog', 'sea cave'],
+  'tropical-monsoon': ['river delta', 'monsoon waterfall', 'limestone cave', 'seasonal lagoon'],
+  'tropical-rainforest': ['jungle river', 'hidden waterfall', 'limestone cave', 'forest spring']
+};
+
+export function getPointsOfInterest(id) {
+  return pointsOfInterestData[id] || [];
+}
+
+export function generatePointsOfInterest(id, count = 3) {
+  const list = getPointsOfInterest(id);
+  const shuffled = [...list];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled.slice(0, Math.min(count, shuffled.length));
+}


### PR DESCRIPTION
## Summary
- Define biome-specific points of interest and helper functions
- Generate and store points of interest when creating locations
- Expose points of interest in biome explorer UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689894ba55708325add5a57bd10719f6