### PR TITLE
Add biome-aware color map generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ duplicate or inconsistent data. Modules currently include:
 - **people** – population details and aggregate statistics.
 - **inventory** – resources with quantity and demand tracking.
 - **location** – geographical generation based on biome.
+- **map** – generates 100×100 pixel color maps scaled to 100 m per tile.
 - **technology** – unlocked technologies which gate other features.
 - **time** – day and season progression.
 

--- a/src/location.js
+++ b/src/location.js
@@ -1,11 +1,13 @@
 import store from './state.js';
 import { getBiome } from './biomes.js';
 import { generatePointsOfInterest } from './pointsOfInterest.js';
+import { generateColorMap } from './map.js';
 
 export function generateLocation(id, biome) {
   const features = getBiome(biome)?.features || [];
   const pointsOfInterest = generatePointsOfInterest(biome);
-  const location = { id, biome, features, pointsOfInterest };
+  const map = generateColorMap(biome);
+  const location = { id, biome, features, pointsOfInterest, map };
   store.addItem('locations', location);
   return location;
 }

--- a/src/map.js
+++ b/src/map.js
@@ -1,0 +1,32 @@
+import { getBiome } from './biomes.js';
+
+export const FEATURE_COLORS = {
+  water: '#1E90FF', // blue
+  open: '#7CFC00', // light green
+  forest: '#228B22' // forest green
+};
+
+function hasWaterFeature(features = []) {
+  return features.some(f => /(water|river|lake|shore|beach|lagoon|reef|marsh|bog|swamp|delta|stream|tide|coast)/i.test(f));
+}
+
+export function generateColorMap(biomeId) {
+  const size = 100;
+  const biome = getBiome(biomeId);
+  const openLand = biome?.openLand ?? 0.5;
+  const waterChance = biome && hasWaterFeature(biome.features) ? 0.2 : 0.05;
+  const pixels = [];
+  for (let y = 0; y < size; y++) {
+    const row = [];
+    for (let x = 0; x < size; x++) {
+      const r = Math.random();
+      let feature;
+      if (r < waterChance) feature = 'water';
+      else if (r < waterChance + openLand) feature = 'open';
+      else feature = 'forest';
+      row.push(FEATURE_COLORS[feature]);
+    }
+    pixels.push(row);
+  }
+  return { scale: 100, pixels };
+}


### PR DESCRIPTION
## Summary
- generate a 100x100 pixel color map with 100 m tiles for each biome
- include generated color maps in location data
- document new map module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898def2839083259bb95a6111a419b0