### PR TITLE
Improve map zoom and procedural generation

### DIFF
--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -17,16 +17,18 @@ let scavengeDisplay = null;
 // aerial view heights without altering the canvas resolution.
 const DEFAULT_MAP_SCALE = 100;
 let mapScale = DEFAULT_MAP_SCALE;
-let mapBaseScale = DEFAULT_MAP_SCALE;
 let mapCanvas = null;
 let scaleDisplay = null;
 const MAP_DISPLAY_SIZE = 600;
 
+// Apply a CSS transform rather than resizing the canvas element. This
+// keeps the canvas resolution consistent while visually zooming the
+// contents to represent different map scales.
 function updateMapDisplay() {
   if (mapCanvas) {
-    const zoomFactor = mapBaseScale / mapScale;
-    mapCanvas.style.width = `${MAP_DISPLAY_SIZE * zoomFactor}px`;
-    mapCanvas.style.height = `${MAP_DISPLAY_SIZE * zoomFactor}px`;
+    const zoomFactor = DEFAULT_MAP_SCALE / mapScale;
+    mapCanvas.style.transform = `scale(${zoomFactor})`;
+    mapCanvas.style.transformOrigin = '0 0';
   }
   if (scaleDisplay) scaleDisplay.textContent = `Grid: ${mapScale}m`;
 }
@@ -219,6 +221,11 @@ export function initGameUI() {
     mapWrapper.style.alignItems = 'flex-start';
     mapWrapper.style.marginTop = '10px';
 
+    const viewport = document.createElement('div');
+    viewport.style.width = `${MAP_DISPLAY_SIZE}px`;
+    viewport.style.height = `${MAP_DISPLAY_SIZE}px`;
+    viewport.style.overflow = 'hidden';
+
     const canvas = document.createElement('canvas');
     const pixels = loc.map.pixels;
     canvas.width = pixels[0].length;
@@ -239,10 +246,13 @@ export function initGameUI() {
     canvas.style.imageRendering = 'pixelated';
     canvas.style.display = 'block';
     canvas.style.margin = '0 auto';
+    canvas.style.width = `${MAP_DISPLAY_SIZE}px`;
+    canvas.style.height = `${MAP_DISPLAY_SIZE}px`;
     mapCanvas = canvas;
     mapScale = loc.map.scale || mapScale;
     updateMapDisplay();
-    mapWrapper.appendChild(canvas);
+    viewport.appendChild(canvas);
+    mapWrapper.appendChild(viewport);
 
     const legend = document.createElement('div');
     legend.style.marginLeft = '20px';

--- a/src/map.js
+++ b/src/map.js
@@ -12,24 +12,84 @@ function hasWaterFeature(features = []) {
 }
 
 export function generateColorMap(biomeId) {
-  const size = 200; // doubled map dimensions
+  const size = 200; // base map dimensions
   const biome = getBiome(biomeId);
   const openLand = biome?.openLand ?? 0.5;
-  const waterChance = biome && hasWaterFeature(biome.features) ? 0.2 : 0.05;
+  const waterFeature = biome && hasWaterFeature(biome.features);
   const oreChance = 0.02; // rare ore deposits
-  const pixels = [];
+
+  // --- Base terrain generation (open land vs forest) ---
+  let terrain = Array.from({ length: size }, () => Array(size).fill('forest'));
   for (let y = 0; y < size; y++) {
-    const row = [];
     for (let x = 0; x < size; x++) {
-      const r = Math.random();
-      let feature;
-      if (r < waterChance) feature = 'water';
-      else if (r < waterChance + oreChance) feature = 'ore';
-      else if (r < waterChance + oreChance + openLand) feature = 'open';
-      else feature = 'forest';
-      row.push(FEATURE_COLORS[feature]);
+      terrain[y][x] = Math.random() < openLand ? 'open' : 'forest';
     }
-    pixels.push(row);
   }
+  // Smooth the terrain to create more contiguous regions
+  for (let iter = 0; iter < 3; iter++) {
+    const next = terrain.map(arr => [...arr]);
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        let openCount = 0;
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            const ny = y + dy, nx = x + dx;
+            if (ny >= 0 && ny < size && nx >= 0 && nx < size && terrain[ny][nx] === 'open') openCount++;
+          }
+        }
+        if (openCount > 4) next[y][x] = 'open';
+        else if (openCount < 4) next[y][x] = 'forest';
+      }
+    }
+    terrain = next;
+  }
+
+  // --- Water features: rivers and lakes ---
+  const riverStart = Math.floor(Math.random() * size);
+  let riverY = riverStart;
+  for (let x = 0; x < size; x++) {
+    for (let w = -1; w <= 1; w++) {
+      const yy = riverY + w;
+      if (yy >= 0 && yy < size) terrain[yy][x] = 'water';
+    }
+    riverY += Math.floor(Math.random() * 3) - 1; // -1, 0, or 1
+    riverY = Math.max(1, Math.min(size - 2, riverY));
+  }
+
+  const lakeCount = waterFeature ? 5 : 2;
+  for (let i = 0; i < lakeCount; i++) {
+    const cx = Math.floor(Math.random() * size);
+    const cy = Math.floor(Math.random() * size);
+    const radius = 3 + Math.floor(Math.random() * 6);
+    for (let dy = -radius; dy <= radius; dy++) {
+      for (let dx = -radius; dx <= radius; dx++) {
+        if (dx * dx + dy * dy <= radius * radius) {
+          const nx = cx + dx;
+          const ny = cy + dy;
+          if (nx >= 0 && nx < size && ny >= 0 && ny < size) terrain[ny][nx] = 'water';
+        }
+      }
+    }
+  }
+
+  // --- Ore deposits ---
+  const oreDeposits = Math.floor(size * oreChance);
+  for (let i = 0; i < oreDeposits; i++) {
+    const cx = Math.floor(Math.random() * size);
+    const cy = Math.floor(Math.random() * size);
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        if (Math.random() < 0.5) {
+          const nx = cx + dx;
+          const ny = cy + dy;
+          if (nx >= 0 && nx < size && ny >= 0 && ny < size) terrain[ny][nx] = 'ore';
+        }
+      }
+    }
+  }
+
+  // Convert terrain types to color values
+  const pixels = terrain.map(row => row.map(cell => FEATURE_COLORS[cell]));
   return { scale: 100, pixels };
 }


### PR DESCRIPTION
## Summary
- Keep map canvas at fixed size and apply CSS transform to zoom, avoiding canvas resizing
- Add viewport wrapper for map and update controls
- Generate procedural maps with rivers, lakes, forests, open land and ore deposits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a0983f9508325acef20a792cd2d86