### PR TITLE
feat: add persistent and scrollable map

### DIFF
--- a/src/persistence.js
+++ b/src/persistence.js
@@ -24,6 +24,10 @@ export function loadGame() {
     for (const loc of store.locations.values()) {
       if (!loc.map || !loc.map.pixels) {
         loc.map = generateColorMap(loc.biome);
+      } else {
+        if (!loc.map.seed) loc.map.seed = Date.now();
+        if (loc.map.xStart === undefined) loc.map.xStart = 0;
+        if (loc.map.yStart === undefined) loc.map.yStart = 0;
       }
     }
     refreshStats();


### PR DESCRIPTION
## Summary
- generate deterministic maps with stored seeds so worlds persist across sessions
- add drag scrolling, recenter control, and dynamic expansion to the map viewport
- persist expanded map regions during play

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a138cbdf48325bb77c3b40ba20e26