### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,27 @@
 <head>
   <meta charset="UTF-8">
   <title>Fantasy Survival</title>
+  <style>
+    :root {
+      --bg-color: #fff;
+      --text-color: #000;
+      --menu-bg: #eee;
+    }
+    body.dark {
+      --bg-color: #222;
+      --text-color: #eee;
+      --menu-bg: #333;
+    }
+    body {
+      background: var(--bg-color);
+      color: var(--text-color);
+    }
+    #top-menu, #bottom-menu {
+      background: var(--menu-bg);
+    }
+  </style>
 </head>
-<body>
+<body class="light">
   <div id="top-menu"></div>
   <div id="content" style="margin-top:40px;">
     <h1>Fantasy Survival</h1>

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,4 +1,5 @@
 let zoomLevel = 1;
+let theme = localStorage.getItem('theme') || 'light';
 
 function applyZoom() {
   const content = document.getElementById('content');
@@ -6,6 +7,11 @@ function applyZoom() {
     content.style.transform = `scale(${zoomLevel})`;
     content.style.transformOrigin = 'top left';
   }
+}
+
+function applyTheme() {
+  document.body.className = theme;
+  localStorage.setItem('theme', theme);
 }
 
 export function showBackButton(show) {
@@ -20,13 +26,14 @@ export function showBackButton(show) {
 export function initTopMenu(onMenu, onBack) {
   const bar = document.getElementById('top-menu');
   if (!bar) return;
+  applyTheme();
   bar.innerHTML = '';
   Object.assign(bar.style, {
     position: 'fixed',
     top: '0',
     left: '0',
     right: '0',
-    background: '#eee',
+    background: 'var(--menu-bg)',
     padding: '4px',
     display: 'flex',
     gap: '4px',
@@ -57,6 +64,18 @@ export function initTopMenu(onMenu, onBack) {
     });
   }
 
+  const themeBtn = document.createElement('button');
+  themeBtn.id = 'theme-btn';
+  const updateThemeIcon = () => {
+    themeBtn.textContent = theme === 'light' ? '🌙' : '☀️';
+  };
+  updateThemeIcon();
+  themeBtn.addEventListener('click', () => {
+    theme = theme === 'light' ? 'dark' : 'light';
+    applyTheme();
+    updateThemeIcon();
+  });
+
   const backBtn = document.createElement('button');
   backBtn.id = 'back-btn';
   backBtn.textContent = 'Back';
@@ -71,6 +90,7 @@ export function initTopMenu(onMenu, onBack) {
   bar.appendChild(zoomOut);
   bar.appendChild(zoomIn);
   bar.appendChild(menuBtn);
+  bar.appendChild(themeBtn);
   bar.appendChild(backBtn);
   applyZoom();
 }
@@ -84,7 +104,7 @@ export function initBottomMenu(onRest) {
     bottom: '0',
     left: '0',
     right: '0',
-    background: '#eee',
+    background: 'var(--menu-bg)',
     padding: '4px',
     display: 'flex',
     justifyContent: 'center',


### PR DESCRIPTION
## Summary
- introduce CSS variables and theme styles to support light and dark modes
- add a sun/moon toggle button in the top menu and persist theme choice
- apply theme-aware colors to top and bottom menus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a14ef422483259a13a3b078879264