### PR TITLE
feat: add elevation-based map generation

### DIFF
--- a/src/biomes.js
+++ b/src/biomes.js
@@ -6,6 +6,7 @@ export const biomes = [
     woodMod: 0.3,
     openLand: 0.2,
     food: 0.2,
+    elevation: { base: 0.8, variance: 0.2, scale: 20, waterLevel: 0.3 },
     description: 'High mountains where trees are sparse and the air is thin.'
   },
   {
@@ -15,6 +16,7 @@ export const biomes = [
     woodMod: 1.0,
     openLand: 0.3,
     food: 0.4,
+    elevation: { base: 0.4, variance: 0.2, scale: 60, waterLevel: 0.3 },
     description: 'Cold northern forests dominated by pines and dotted with bogs.'
   },
   {
@@ -24,6 +26,7 @@ export const biomes = [
     woodMod: 0.8,
     openLand: 0.5,
     food: 0.6,
+    elevation: { base: 0.2, variance: 0.1, scale: 50, waterLevel: 0.15 },
     description: 'Cool coasts with rocky beaches and windswept cliffs.'
   },
   {
@@ -33,6 +36,7 @@ export const biomes = [
     woodMod: 0.9,
     openLand: 0.5,
     food: 0.9,
+    elevation: { base: 0.2, variance: 0.1, scale: 50, waterLevel: 0.15 },
     description: 'Warm shores of sand and reef washed by gentle tropical seas.'
   },
   {
@@ -42,6 +46,7 @@ export const biomes = [
     woodMod: 0.7,
     openLand: 0.4,
     food: 0.6,
+    elevation: { base: 0.1, variance: 0.05, scale: 80, waterLevel: 0.2 },
     description: 'Waterlogged plains filled with reeds, marshes and standing water.'
   },
   {
@@ -51,6 +56,7 @@ export const biomes = [
     woodMod: 0.8,
     openLand: 0.5,
     food: 0.7,
+    elevation: { base: 0.25, variance: 0.1, scale: 40, waterLevel: 0.2 },
     description: 'A temperate island with forests, cliffs and cool seas.'
   },
   {
@@ -60,6 +66,7 @@ export const biomes = [
     woodMod: 0.9,
     openLand: 0.5,
     food: 0.9,
+    elevation: { base: 0.25, variance: 0.1, scale: 40, waterLevel: 0.2 },
     description: 'Lush tropical islands fringed by palms and volcanic heights.'
   },
   {
@@ -69,6 +76,7 @@ export const biomes = [
     woodMod: 1.0,
     openLand: 0.3,
     food: 0.8,
+    elevation: { base: 0.15, variance: 0.05, scale: 30, waterLevel: 0.18 },
     description: 'Dense coastal forests rooted in tidal mud and brackish water.'
   },
   {
@@ -78,6 +86,7 @@ export const biomes = [
     woodMod: 0.9,
     openLand: 0.6,
     food: 0.7,
+    elevation: { base: 0.3, variance: 0.15, scale: 70, waterLevel: 0.2 },
     description: 'Warm dry woodlands with scrub and hardy trees.'
   },
   {
@@ -87,6 +96,7 @@ export const biomes = [
     woodMod: 0.8,
     openLand: 0.3,
     food: 0.5,
+    elevation: { base: 0.6, variance: 0.2, scale: 40, waterLevel: 0.25 },
     description: 'High elevation forests perpetually shrouded in mist.'
   },
   {
@@ -96,6 +106,7 @@ export const biomes = [
     woodMod: 0.6,
     openLand: 0.8,
     food: 0.5,
+    elevation: { base: 0.3, variance: 0.15, scale: 80, waterLevel: 0.18 },
     description: 'Vast grassy plains dotted with trees and seasonal water.'
   },
   {
@@ -105,6 +116,7 @@ export const biomes = [
     woodMod: 1.1,
     openLand: 0.6,
     food: 0.7,
+    elevation: { base: 0.35, variance: 0.15, scale: 60, waterLevel: 0.2 },
     description: 'Forests of broadleaf trees that change with the seasons.'
   },
   {
@@ -114,6 +126,7 @@ export const biomes = [
     woodMod: 1.1,
     openLand: 0.4,
     food: 0.8,
+    elevation: { base: 0.3, variance: 0.15, scale: 50, waterLevel: 0.2 },
     description: 'Mild coastal forests kept lush by constant rain and fog.'
   },
   {
@@ -123,6 +136,7 @@ export const biomes = [
     woodMod: 1.0,
     openLand: 0.5,
     food: 1.0,
+    elevation: { base: 0.3, variance: 0.2, scale: 60, waterLevel: 0.25 },
     description: 'Tropical forests with distinct wet and dry seasons.'
   },
   {
@@ -132,6 +146,7 @@ export const biomes = [
     woodMod: 1.2,
     openLand: 0.3,
     food: 1.2,
+    elevation: { base: 0.35, variance: 0.15, scale: 70, waterLevel: 0.25 },
     description: 'Hot, humid jungles teeming with life and thick vegetation.'
   }
 ];


### PR DESCRIPTION
## Summary
- add biome-specific elevation metadata
- integrate elevation noise into color map generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a16d603a08325a89f70a215fa2cae