### PR TITLE
Add slide-down top menu and relocate controls

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,11 +52,11 @@ function startGame(settings = {}) {
 }
 
 function init() {
-  initTopMenu(showJobs, closeJobs);
-  initBottomMenu(() => {
+  initTopMenu(showJobs, closeJobs, () => {
     clearSave();
     window.location.reload();
   });
+  initBottomMenu();
   if (!loadGame()) {
     initSetupUI(startGame);
   } else {

--- a/src/menu.js
+++ b/src/menu.js
@@ -16,14 +16,14 @@ function applyTheme() {
 
 export function showBackButton(show) {
   const back = document.getElementById('back-btn');
-  const menu = document.getElementById('menu-btn');
-  if (back && menu) {
+  const menuWrapper = document.getElementById('menu-wrapper');
+  if (back && menuWrapper) {
     back.style.display = show ? 'inline-block' : 'none';
-    menu.style.display = show ? 'none' : 'inline-block';
+    menuWrapper.style.display = show ? 'none' : 'inline-block';
   }
 }
 
-export function initTopMenu(onMenu, onBack) {
+export function initTopMenu(onMenu, onBack, onReset) {
   const bar = document.getElementById('top-menu');
   if (!bar) return;
   applyTheme();
@@ -37,33 +37,18 @@ export function initTopMenu(onMenu, onBack) {
     padding: '4px',
     display: 'flex',
     gap: '4px',
-    zIndex: '1000'
+    zIndex: '1000',
+    alignItems: 'flex-start'
   });
 
-  const zoomOut = document.createElement('button');
-  zoomOut.textContent = '-';
-  zoomOut.addEventListener('click', () => {
-    zoomLevel = Math.max(0.5, Math.round((zoomLevel - 0.1) * 10) / 10);
-    applyZoom();
-  });
-
-  const zoomIn = document.createElement('button');
-  zoomIn.textContent = '+';
-  zoomIn.addEventListener('click', () => {
-    zoomLevel = Math.min(2, Math.round((zoomLevel + 0.1) * 10) / 10);
-    applyZoom();
-  });
-
-  const menuBtn = document.createElement('button');
-  menuBtn.id = 'menu-btn';
-  menuBtn.textContent = 'Menu';
-  if (typeof onMenu === 'function') {
-    menuBtn.addEventListener('click', () => {
-      onMenu();
-      showBackButton(true);
-    });
-  }
-
+  const squareStyle = {
+    width: '32px',
+    height: '32px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '0'
+  };
   const themeBtn = document.createElement('button');
   themeBtn.id = 'theme-btn';
   const updateThemeIcon = () => {
@@ -76,6 +61,79 @@ export function initTopMenu(onMenu, onBack) {
     updateThemeIcon();
   });
 
+  const zoomOut = document.createElement('button');
+  zoomOut.textContent = '-';
+  Object.assign(zoomOut.style, squareStyle);
+  zoomOut.addEventListener('click', () => {
+    zoomLevel = Math.max(0.5, Math.round((zoomLevel - 0.1) * 10) / 10);
+    applyZoom();
+  });
+
+  const zoomIn = document.createElement('button');
+  zoomIn.textContent = '+';
+  Object.assign(zoomIn.style, squareStyle);
+  zoomIn.addEventListener('click', () => {
+    zoomLevel = Math.min(2, Math.round((zoomLevel + 0.1) * 10) / 10);
+    applyZoom();
+  });
+
+  const menuBtn = document.createElement('button');
+  menuBtn.id = 'menu-btn';
+  menuBtn.textContent = 'Menu';
+
+  const menuWrapper = document.createElement('div');
+  menuWrapper.id = 'menu-wrapper';
+  menuWrapper.style.position = 'relative';
+  menuWrapper.appendChild(menuBtn);
+
+  const dropdown = document.createElement('div');
+  dropdown.id = 'dropdown-menu';
+  Object.assign(dropdown.style, {
+    position: 'absolute',
+    top: '100%',
+    left: '0',
+    background: 'var(--menu-bg)',
+    display: 'none',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    maxHeight: '0',
+    transition: 'max-height 0.3s ease-out',
+    zIndex: '1001'
+  });
+  menuWrapper.appendChild(dropdown);
+
+  let menuOpen = false;
+  function toggleMenu(open) {
+    menuOpen = open !== undefined ? open : !menuOpen;
+    if (menuOpen) {
+      dropdown.style.display = 'flex';
+      dropdown.style.maxHeight = dropdown.scrollHeight + 'px';
+    } else {
+      dropdown.style.maxHeight = '0';
+      setTimeout(() => { if (!menuOpen) dropdown.style.display = 'none'; }, 300);
+    }
+  }
+  menuBtn.addEventListener('click', () => toggleMenu());
+
+  if (typeof onMenu === 'function') {
+    const jobsBtn = document.createElement('button');
+    jobsBtn.textContent = 'Jobs';
+    jobsBtn.addEventListener('click', () => {
+      toggleMenu(false);
+      onMenu();
+      showBackButton(true);
+    });
+    dropdown.appendChild(jobsBtn);
+  }
+
+  const resetBtn = document.createElement('button');
+  resetBtn.textContent = 'New Game';
+  resetBtn.addEventListener('click', () => {
+    toggleMenu(false);
+    if (typeof onReset === 'function') onReset();
+  });
+  dropdown.appendChild(resetBtn);
+
   const backBtn = document.createElement('button');
   backBtn.id = 'back-btn';
   backBtn.textContent = 'Back';
@@ -87,10 +145,10 @@ export function initTopMenu(onMenu, onBack) {
     });
   }
 
+  bar.appendChild(themeBtn);
   bar.appendChild(zoomOut);
   bar.appendChild(zoomIn);
-  bar.appendChild(menuBtn);
-  bar.appendChild(themeBtn);
+  bar.appendChild(menuWrapper);
   bar.appendChild(backBtn);
   applyZoom();
 }
@@ -111,11 +169,11 @@ export function initBottomMenu(onRest) {
     zIndex: '1000'
   });
 
-  const restBtn = document.createElement('button');
-  restBtn.textContent = 'Rest';
   if (typeof onRest === 'function') {
+    const restBtn = document.createElement('button');
+    restBtn.textContent = 'Rest';
     restBtn.addEventListener('click', onRest);
+    bar.appendChild(restBtn);
   }
-  bar.appendChild(restBtn);
 }
 


### PR DESCRIPTION
## Summary
- Move theme toggle to left edge and standardize zoom buttons
- Implement slide-down menu toggled by Menu button with persistent toggle
- Add `New Game` option in menu and remove reset from bottom bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2a90b890832593032036584bdb05