### PR TITLE
Align menu button sizes and refine map zoom controls

### DIFF
--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -394,7 +394,7 @@ export function initGameUI() {
     const zoomIn = document.createElement('button');
     zoomIn.textContent = 'Zoom In';
     zoomIn.addEventListener('click', () => {
-      mapScale = Math.max(1, Math.round(mapScale / 1.5));
+      mapScale = Math.max(10, mapScale - 10);
       loc.map.scale = mapScale;
       updateMapDisplay();
       ensureMapCoverage();
@@ -402,7 +402,7 @@ export function initGameUI() {
     const zoomOut = document.createElement('button');
     zoomOut.textContent = 'Zoom Out';
     zoomOut.addEventListener('click', () => {
-      mapScale = Math.round(mapScale * 1.5);
+      mapScale += 10;
       loc.map.scale = mapScale;
       updateMapDisplay();
       ensureMapCoverage();

--- a/src/menu.js
+++ b/src/menu.js
@@ -51,6 +51,7 @@ export function initTopMenu(onMenu, onBack, onReset) {
   };
   const themeBtn = document.createElement('button');
   themeBtn.id = 'theme-btn';
+  Object.assign(themeBtn.style, squareStyle);
   const updateThemeIcon = () => {
     themeBtn.textContent = theme === 'light' ? '🌙' : '☀️';
   };
@@ -80,6 +81,7 @@ export function initTopMenu(onMenu, onBack, onReset) {
   const menuBtn = document.createElement('button');
   menuBtn.id = 'menu-btn';
   menuBtn.textContent = 'Menu';
+  Object.assign(menuBtn.style, { height: squareStyle.height });
 
   const menuWrapper = document.createElement('div');
   menuWrapper.id = 'menu-wrapper';
@@ -115,29 +117,31 @@ export function initTopMenu(onMenu, onBack, onReset) {
   }
   menuBtn.addEventListener('click', () => toggleMenu());
 
-  if (typeof onMenu === 'function') {
-    const jobsBtn = document.createElement('button');
-    jobsBtn.textContent = 'Jobs';
-    jobsBtn.addEventListener('click', () => {
-      toggleMenu(false);
-      onMenu();
-      showBackButton(true);
-    });
-    dropdown.appendChild(jobsBtn);
-  }
+    if (typeof onMenu === 'function') {
+      const jobsBtn = document.createElement('button');
+      jobsBtn.textContent = 'Jobs';
+      Object.assign(jobsBtn.style, { height: squareStyle.height });
+      jobsBtn.addEventListener('click', () => {
+        toggleMenu(false);
+        onMenu();
+        showBackButton(true);
+      });
+      dropdown.appendChild(jobsBtn);
+    }
 
-  const resetBtn = document.createElement('button');
-  resetBtn.textContent = 'New Game';
-  resetBtn.addEventListener('click', () => {
-    toggleMenu(false);
-    if (typeof onReset === 'function') onReset();
-  });
-  dropdown.appendChild(resetBtn);
+    const resetBtn = document.createElement('button');
+    resetBtn.textContent = 'New Game';
+    Object.assign(resetBtn.style, { height: squareStyle.height });
+    resetBtn.addEventListener('click', () => {
+      toggleMenu(false);
+      if (typeof onReset === 'function') onReset();
+    });
+    dropdown.appendChild(resetBtn);
 
   const backBtn = document.createElement('button');
   backBtn.id = 'back-btn';
   backBtn.textContent = 'Back';
-  backBtn.style.display = 'none';
+  Object.assign(backBtn.style, { height: squareStyle.height, display: 'none' });
   if (typeof onBack === 'function') {
     backBtn.addEventListener('click', () => {
       onBack();


### PR DESCRIPTION
## Summary
- Standardize top-menu button heights and make the theme toggle the same square size as zoom controls
- Update Jobs, New Game, Menu, and Back buttons for consistent 32px height
- Change map zoom to adjust the map scale in 10m increments from the 100m base

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a30917a2c83259b755fc3b74e9d60