### PR TITLE
Add seasonal biome map color themes

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -3,10 +3,10 @@ import { getBiome } from './biomes.js';
 import { generatePointsOfInterest } from './pointsOfInterest.js';
 import { generateColorMap } from './map.js';
 
-export function generateLocation(id, biome) {
+export function generateLocation(id, biome, season = store.time.season) {
   const features = getBiome(biome)?.features || [];
   const pointsOfInterest = generatePointsOfInterest(biome);
-  const map = generateColorMap(biome);
+  const map = generateColorMap(biome, Date.now(), 0, 0, 200, 200, season);
   const location = { id, biome, features, pointsOfInterest, map };
   store.addItem('locations', location);
   return location;

--- a/src/main.js
+++ b/src/main.js
@@ -26,15 +26,14 @@ function startGame(settings = {}) {
 
   Object.entries(cfg.tools).forEach(([item, qty]) => addItem(item, qty));
 
+  if (settings.season) store.time.season = settings.season;
   if (settings.biome) {
-    generateLocation('loc1', settings.biome);
+    generateLocation('loc1', settings.biome, store.time.season);
   } else if (store.locations.size === 0) {
-    generateLocation('loc1', 'temperate-deciduous');
+    generateLocation('loc1', 'temperate-deciduous', store.time.season);
   }
   shelterTypes.forEach(registerBuildingType);
   unlockTechnology({ id: 'basic-tools', name: 'Basic Tools' });
-
-  if (settings.season) store.time.season = settings.season;
   store.difficulty = diff;
   // Initialize available jobs, starting with scavenging
   store.jobs = { scavenge: 0 };

--- a/src/map.js
+++ b/src/map.js
@@ -1,11 +1,105 @@
 import { getBiome } from './biomes.js';
+import store from './state.js';
 
-export const FEATURE_COLORS = {
-  water: '#1E90FF', // blue
-  open: '#7CFC00', // light green
-  forest: '#228B22', // forest green
-  ore: '#B87333' // coppery brown for ore deposits
+// Color themes for each biome and season
+export const BIOME_COLOR_THEMES = {
+  alpine: {
+    Spring: { water: '#1E90FF', open: '#9ACD32', forest: '#2E8B57', ore: '#B87333' },
+    Summer: { water: '#1E90FF', open: '#7CFC00', forest: '#228B22', ore: '#B87333' },
+    Autumn: { water: '#1E90FF', open: '#DEB887', forest: '#556B2F', ore: '#B87333' },
+    Winter: { water: '#ADD8E6', open: '#FFFFFF', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  'boreal-taiga': {
+    Spring: { water: '#4682B4', open: '#98FB98', forest: '#2E8B57', ore: '#B87333' },
+    Summer: { water: '#4682B4', open: '#6B8E23', forest: '#006400', ore: '#B87333' },
+    Autumn: { water: '#4682B4', open: '#CD853F', forest: '#556B2F', ore: '#B87333' },
+    Winter: { water: '#87CEFA', open: '#F5F5F5', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  'coastal-temperate': {
+    Spring: { water: '#87CEFA', open: '#90EE90', forest: '#228B22', ore: '#B87333' },
+    Summer: { water: '#1E90FF', open: '#7CFC00', forest: '#006400', ore: '#B87333' },
+    Autumn: { water: '#87CEEB', open: '#DAA520', forest: '#8B4513', ore: '#B87333' },
+    Winter: { water: '#B0C4DE', open: '#D3D3D3', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  'coastal-tropical': {
+    Spring: { water: '#00CED1', open: '#FFE4B5', forest: '#2E8B57', ore: '#B87333' },
+    Summer: { water: '#00CED1', open: '#FFDAB9', forest: '#228B22', ore: '#B87333' },
+    Autumn: { water: '#00CED1', open: '#FFE4B5', forest: '#228B22', ore: '#B87333' },
+    Winter: { water: '#00CED1', open: '#FFE4B5', forest: '#228B22', ore: '#B87333' }
+  },
+  'flooded-grasslands': {
+    Spring: { water: '#2E8B57', open: '#ADFF2F', forest: '#556B2F', ore: '#B87333' },
+    Summer: { water: '#228B22', open: '#7FFF00', forest: '#006400', ore: '#B87333' },
+    Autumn: { water: '#2E8B57', open: '#CD853F', forest: '#556B2F', ore: '#B87333' },
+    Winter: { water: '#4682B4', open: '#F0E68C', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  'island-temperate': {
+    Spring: { water: '#1E90FF', open: '#90EE90', forest: '#228B22', ore: '#B87333' },
+    Summer: { water: '#1E90FF', open: '#7CFC00', forest: '#006400', ore: '#B87333' },
+    Autumn: { water: '#1E90FF', open: '#DAA520', forest: '#8B4513', ore: '#B87333' },
+    Winter: { water: '#87CEEB', open: '#D3D3D3', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  'island-tropical': {
+    Spring: { water: '#00BFFF', open: '#FFE4B5', forest: '#2E8B57', ore: '#B87333' },
+    Summer: { water: '#00BFFF', open: '#FFDAB9', forest: '#228B22', ore: '#B87333' },
+    Autumn: { water: '#00BFFF', open: '#FFE4B5', forest: '#228B22', ore: '#B87333' },
+    Winter: { water: '#00BFFF', open: '#FFE4B5', forest: '#228B22', ore: '#B87333' }
+  },
+  mangrove: {
+    Spring: { water: '#2F4F4F', open: '#BDB76B', forest: '#556B2F', ore: '#B87333' },
+    Summer: { water: '#2F4F4F', open: '#BDB76B', forest: '#2E8B57', ore: '#B87333' },
+    Autumn: { water: '#2F4F4F', open: '#CD853F', forest: '#556B2F', ore: '#B87333' },
+    Winter: { water: '#2F4F4F', open: '#C0C0C0', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  'mediterranean-woodland': {
+    Spring: { water: '#4682B4', open: '#9ACD32', forest: '#556B2F', ore: '#B87333' },
+    Summer: { water: '#4682B4', open: '#C2B280', forest: '#6B8E23', ore: '#B87333' },
+    Autumn: { water: '#4682B4', open: '#CD853F', forest: '#8B4513', ore: '#B87333' },
+    Winter: { water: '#4682B4', open: '#D3D3D3', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  'montane-cloud': {
+    Spring: { water: '#87CEEB', open: '#66CDAA', forest: '#2E8B57', ore: '#B87333' },
+    Summer: { water: '#87CEEB', open: '#7FFFD4', forest: '#228B22', ore: '#B87333' },
+    Autumn: { water: '#87CEEB', open: '#DAA520', forest: '#556B2F', ore: '#B87333' },
+    Winter: { water: '#B0E0E6', open: '#F0F8FF', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  savanna: {
+    Spring: { water: '#1E90FF', open: '#ADFF2F', forest: '#556B2F', ore: '#B87333' },
+    Summer: { water: '#1E90FF', open: '#DAA520', forest: '#6B8E23', ore: '#B87333' },
+    Autumn: { water: '#1E90FF', open: '#CD853F', forest: '#8B4513', ore: '#B87333' },
+    Winter: { water: '#1E90FF', open: '#F0E68C', forest: '#808000', ore: '#B87333' }
+  },
+  'temperate-deciduous': {
+    Spring: { water: '#1E90FF', open: '#90EE90', forest: '#228B22', ore: '#B87333' },
+    Summer: { water: '#1E90FF', open: '#7CFC00', forest: '#006400', ore: '#B87333' },
+    Autumn: { water: '#1E90FF', open: '#DEB887', forest: '#8B4513', ore: '#B87333' },
+    Winter: { water: '#87CEFA', open: '#F5F5F5', forest: '#A9A9A9', ore: '#B87333' }
+  },
+  'temperate-rainforest': {
+    Spring: { water: '#4682B4', open: '#90EE90', forest: '#2E8B57', ore: '#B87333' },
+    Summer: { water: '#4682B4', open: '#7CFC00', forest: '#006400', ore: '#B87333' },
+    Autumn: { water: '#4682B4', open: '#8FBC8F', forest: '#556B2F', ore: '#B87333' },
+    Winter: { water: '#4682B4', open: '#98FB98', forest: '#2F4F4F', ore: '#B87333' }
+  },
+  'tropical-monsoon': {
+    Spring: { water: '#00CED1', open: '#32CD32', forest: '#228B22', ore: '#B87333' },
+    Summer: { water: '#00CED1', open: '#7CFC00', forest: '#006400', ore: '#B87333' },
+    Autumn: { water: '#00CED1', open: '#ADFF2F', forest: '#228B22', ore: '#B87333' },
+    Winter: { water: '#00CED1', open: '#C2B280', forest: '#556B2F', ore: '#B87333' }
+  },
+  'tropical-rainforest': {
+    Spring: { water: '#00BFFF', open: '#32CD32', forest: '#006400', ore: '#B87333' },
+    Summer: { water: '#00BFFF', open: '#00FF7F', forest: '#006400', ore: '#B87333' },
+    Autumn: { water: '#00BFFF', open: '#3CB371', forest: '#228B22', ore: '#B87333' },
+    Winter: { water: '#00BFFF', open: '#2E8B57', forest: '#2E8B57', ore: '#B87333' }
+  }
 };
+
+export function getFeatureColors(biomeId, season = store.time.season) {
+  const biomeColors = BIOME_COLOR_THEMES[biomeId];
+  if (biomeColors && biomeColors[season]) return biomeColors[season];
+  return { water: '#1E90FF', open: '#7CFC00', forest: '#228B22', ore: '#B87333' };
+}
 
 export function hasWaterFeature(features = []) {
   return features.some(f => /(water|river|lake|shore|beach|lagoon|reef|marsh|bog|swamp|delta|stream|tide|coast)/i.test(f));
@@ -76,13 +170,15 @@ export function generateColorMap(
   xStart = 0,
   yStart = 0,
   width = 200,
-  height = 200
+  height = 200,
+  season = store.time.season
 ) {
   const biome = getBiome(biomeId);
   const openLand = biome?.openLand ?? 0.5;
   const waterFeature = biome && hasWaterFeature(biome.features);
   const pixels = [];
   const elevations = [];
+  const colors = getFeatureColors(biomeId, season);
 
   for (let y = 0; y < height; y++) {
     const row = [];
@@ -96,18 +192,18 @@ export function generateColorMap(
       const waterLevel = biome?.elevation?.waterLevel ?? 0.3;
       if (waterFeature && elevation < waterLevel) type = 'water';
       if (coordRand(seed, gx, gy, 'ore') < 0.02 && elevation >= waterLevel) type = 'ore';
-      row.push(FEATURE_COLORS[type]);
+      row.push(colors[type]);
     }
     pixels.push(row);
     elevations.push(eRow);
   }
 
-  return { scale: 100, seed, xStart, yStart, pixels, elevations };
+  return { scale: 100, seed, xStart, yStart, pixels, elevations, season };
 }
-
-export function getBiomeBorderColor(biomeId) {
+export function getBiomeBorderColor(biomeId, season = store.time.season) {
   const biome = getBiome(biomeId);
-  if (!biome) return FEATURE_COLORS.open;
-  if (hasWaterFeature(biome.features)) return FEATURE_COLORS.water;
-  return biome.openLand > 0.5 ? FEATURE_COLORS.open : FEATURE_COLORS.forest;
+  const colors = getFeatureColors(biomeId, season);
+  if (!biome) return colors.open;
+  if (hasWaterFeature(biome.features)) return colors.water;
+  return biome.openLand > 0.5 ? colors.open : colors.forest;
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,7 +5,7 @@
 
 import { biomes, getBiome } from './biomes.js';
 import { difficulties, difficultySettings } from './difficulty.js';
-import { generateColorMap, FEATURE_COLORS, getBiomeBorderColor } from './map.js';
+import { generateColorMap, getFeatureColors, getBiomeBorderColor } from './map.js';
 
 const seasons = ['Spring', 'Summer', 'Autumn', 'Winter'];
 
@@ -85,28 +85,33 @@ export function initSetupUI(onStart) {
     const legend = document.createElement('div');
     legend.style.marginLeft = '20px';
     const title = document.createElement('h3');
-    title.textContent = getBiome(biomeSelect.select.value)?.name || biomeSelect.select.value;
     legend.appendChild(title);
     const list = document.createElement('ul');
+    legend.appendChild(list);
     const labels = {
       water: 'Bodies of Water',
       open: 'Open Land',
       forest: 'Forest',
       ore: 'Ore Deposits'
     };
-    Object.entries(FEATURE_COLORS).forEach(([key, color]) => {
-      const li = document.createElement('li');
-      const swatch = document.createElement('span');
-      swatch.style.display = 'inline-block';
-      swatch.style.width = '12px';
-      swatch.style.height = '12px';
-      swatch.style.backgroundColor = color;
-      swatch.style.marginRight = '6px';
-      li.appendChild(swatch);
-      li.appendChild(document.createTextNode(labels[key] || key));
-      list.appendChild(li);
-    });
-    legend.appendChild(list);
+    const updateLegend = () => {
+      list.innerHTML = '';
+      const colors = getFeatureColors(biomeSelect.select.value, seasonSelect.select.value);
+      Object.entries(colors).forEach(([key, color]) => {
+        const li = document.createElement('li');
+        const swatch = document.createElement('span');
+        swatch.style.display = 'inline-block';
+        swatch.style.width = '12px';
+        swatch.style.height = '12px';
+        swatch.style.backgroundColor = color;
+        swatch.style.marginRight = '6px';
+        li.appendChild(swatch);
+        li.appendChild(document.createTextNode(labels[key] || key));
+        list.appendChild(li);
+      });
+      title.textContent = getBiome(biomeSelect.select.value)?.name || biomeSelect.select.value;
+    };
+    updateLegend();
     mapWrapper.appendChild(legend);
     form.appendChild(mapWrapper);
 
@@ -227,13 +232,14 @@ export function initSetupUI(onStart) {
         -MAP_DISPLAY_SIZE / 2,
         -MAP_DISPLAY_SIZE / 2,
         MAP_DISPLAY_SIZE,
-        MAP_DISPLAY_SIZE
+        MAP_DISPLAY_SIZE,
+        seasonSelect.select.value
       );
       renderMap();
       centerMap();
       updateMapDisplay();
-      viewport.style.border = `4px solid ${getBiomeBorderColor(biomeId)}`;
-      title.textContent = getBiome(biomeId)?.name || biomeId;
+      viewport.style.border = `4px solid ${getBiomeBorderColor(biomeId, seasonSelect.select.value)}`;
+      updateLegend();
     };
 
     centerBtn.addEventListener('click', () => {
@@ -293,6 +299,7 @@ export function initSetupUI(onStart) {
       updateBiomeInfo();
       generatePreview();
     });
+    seasonSelect.select.addEventListener('change', generatePreview);
   diffSelect.select.addEventListener('change', updateDiffInfo);
     updateBiomeInfo();
     updateDiffInfo();


### PR DESCRIPTION
## Summary
- add distinct color themes for every biome and season
- render maps using biome- and season-specific palettes
- update UI legends and map borders when seasons change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aae57f5e48325b1f5f1a58354abd4