### PR TITLE
feat: add water category and controls

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -218,7 +218,7 @@ export function generateColorMap(
     elevations.push(eRow);
   }
 
-  return { scale: 100, seed, xStart, yStart, pixels, elevations, season };
+  return { scale: 100, seed, xStart, yStart, pixels, elevations, season, waterLevel };
 }
 export function getBiomeBorderColor(biomeId, season = store.time.season) {
   const biome = getBiome(biomeId);


### PR DESCRIPTION
## Summary
- add collapsible water section to map legends
- expose water level with up/down buttons and reset
- allow per-feature water counts for biome-relevant features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e822b3ae08325aa4a92c9affa5aa1