### PR TITLE
Fix setup legend initialization to restore UI loading

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -88,6 +88,13 @@ export function initSetupUI(onStart) {
 
   mapSection.appendChild(seedRow);
 
+  const LEGEND_LABELS = {
+    water: 'Water',
+    open: 'Open Land',
+    forest: 'Forest',
+    ore: 'Ore Deposits'
+  };
+
   const mapView = createMapView(mapSection, {
     legendLabels: LEGEND_LABELS,
     showControls: true,
@@ -103,13 +110,6 @@ export function initSetupUI(onStart) {
   form.appendChild(startBtn);
 
   container.appendChild(form);
-
-  const LEGEND_LABELS = {
-    water: 'Water',
-    open: 'Open Land',
-    forest: 'Forest',
-    ore: 'Ore Deposits'
-  };
 
   function updateInfo() {
     const biome = getBiome(biomeSelect.select.value);


### PR DESCRIPTION
## Summary
- define the setup map legend before passing it to the map view to prevent runtime errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd8a22e6588325a17f20bb41bbf074