### PR TITLE
Fix missing timeInfo export causing UI crash

### DIFF
--- a/src/time.js
+++ b/src/time.js
@@ -25,6 +25,10 @@ export function info() {
   return { ...store.time };
 }
 
+// Provide a backwards-compatible alias for modules that import `timeInfo`.
+// This is useful for legacy code that still expects the older export name.
+export { info as timeInfo };
+
 export function resetToDawn() {
   store.time.hour = DAWN_HOUR;
 }


### PR DESCRIPTION
## Summary
- add a backwards-compatible `timeInfo` export alias to the time module so legacy imports succeed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd96d9e27083259fcaa1a43b53d5bf