### PR TITLE
Refresh map viewport on movement

### DIFF
--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -52,7 +52,11 @@ let lockedList = null;
 function renderTextMap() {
   const loc = allLocations()[0];
   if (!loc || !mapView) return;
-  mapView.setMap(loc.map);
+  mapView.setMap(loc.map, {
+    biomeId: loc.biome,
+    seed: loc.map?.seed,
+    season: loc.map?.season
+  });
 }
 
 function formatHour(hour = 0) {
@@ -773,9 +777,29 @@ export function initGameUI() {
       legendLabels: LEGEND_LABELS,
       showControls: true,
       showLegend: true,
-      idPrefix: 'game-map'
+      idPrefix: 'game-map',
+      fetchMap: ({ xStart, yStart, width, height, seed, season }) => {
+        const baseSeed = seed ?? loc.map?.seed ?? Date.now();
+        const baseSeason = season ?? store.time.season;
+        return generateColorMap(
+          loc.biome,
+          baseSeed,
+          xStart,
+          yStart,
+          width,
+          height,
+          baseSeason
+        );
+      },
+      onMapUpdate: updated => {
+        loc.map = { ...loc.map, ...updated };
+      }
     });
-    mapView.setMap(loc.map);
+    mapView.setMap(loc.map, {
+      biomeId: loc.biome,
+      seed: loc.map?.seed,
+      season: loc.map?.season
+    });
 
     container.appendChild(mapSection);
     lastSeason = store.time.season;

--- a/src/ui.js
+++ b/src/ui.js
@@ -99,7 +99,24 @@ export function initSetupUI(onStart) {
     legendLabels: LEGEND_LABELS,
     showControls: true,
     showLegend: true,
-    idPrefix: 'setup-map'
+    idPrefix: 'setup-map',
+    fetchMap: ({ xStart, yStart, width, height, seed, season, context }) => {
+      const biomeId = context?.biomeId || biomeSelect.select.value;
+      const nextSeed = seed ?? mapSeed;
+      const nextSeason = season ?? seasonSelect.select.value;
+      return generateColorMap(
+        biomeId,
+        nextSeed,
+        xStart,
+        yStart,
+        width,
+        height,
+        nextSeason
+      );
+    },
+    onMapUpdate: updated => {
+      mapData = { ...updated };
+    }
   });
 
   form.appendChild(mapSection);
@@ -133,7 +150,11 @@ export function initSetupUI(onStart) {
 
   function renderMapPreview() {
     if (!mapData) return;
-    mapView.setMap(mapData);
+    mapView.setMap(mapData, {
+      biomeId: biomeSelect.select.value,
+      seed: mapData?.seed ?? mapSeed,
+      season: mapData?.season ?? seasonSelect.select.value
+    });
   }
 
   function generatePreview() {


### PR DESCRIPTION
## Summary
- hide map view scrollbars and resize the display to fill its container
- regenerate terrain deterministically when the map is panned or dragged
- wire the setup and in-game UIs to supply map generation callbacks for viewport changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd9b516c78832598fbf0b9da9c94ef