### PR TITLE
Add construction dashboard modal and highlight starting tile

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import { calculateStartingGoods, harvestWood } from './resources.js';
 import { initSetupUI } from './ui.js';
 import { saveGame, loadGame, clearSave } from './persistence.js';
 import { difficultySettings } from './difficulty.js';
-import { initGameUI, showJobs, closeJobs } from './gameUI.js';
+import { initGameUI, showJobs, closeJobs, showConstructionDashboard } from './gameUI.js';
 import { initTopMenu, initBottomMenu } from './menu.js';
 import { resetToDawn } from './time.js';
 import { resetOrders } from './orders.js';
@@ -56,7 +56,7 @@ function init() {
   initTopMenu(showJobs, closeJobs, () => {
     clearSave();
     window.location.reload();
-  });
+  }, showConstructionDashboard);
   initBottomMenu();
   if (!loadGame()) {
     initSetupUI(startGame);

--- a/src/map.js
+++ b/src/map.js
@@ -120,7 +120,13 @@ export function generateColorMap(
         const oreVal = oreNoise(seed, gx, gy, 12);
         if (oreVal > 0.85 && elevation >= waterLevel) type = 'ore';
       }
-      row.push(TERRAIN_SYMBOLS[type] || '?');
+
+      if (gx === 0 && gy === 0) {
+        type = 'open';
+      }
+
+      const symbol = gx === 0 && gy === 0 ? '🚩' : TERRAIN_SYMBOLS[type] || '?';
+      row.push(symbol);
       typeRow.push(type);
     }
     tiles.push(row);

--- a/src/menu.js
+++ b/src/menu.js
@@ -17,13 +17,17 @@ function applyTheme() {
 export function showBackButton(show) {
   const back = document.getElementById('back-btn');
   const menuWrapper = document.getElementById('menu-wrapper');
+  const constructionBtn = document.getElementById('construction-btn');
   if (back && menuWrapper) {
     back.style.display = show ? 'inline-block' : 'none';
     menuWrapper.style.display = show ? 'none' : 'inline-block';
   }
+  if (constructionBtn) {
+    constructionBtn.style.display = show ? 'none' : 'inline-block';
+  }
 }
 
-export function initTopMenu(onMenu, onBack, onReset) {
+export function initTopMenu(onMenu, onBack, onReset, onConstruction) {
   const bar = document.getElementById('top-menu');
   if (!bar) return;
   applyTheme();
@@ -78,6 +82,14 @@ export function initTopMenu(onMenu, onBack, onReset) {
     applyZoom();
   });
 
+  const constructionBtn = document.createElement('button');
+  constructionBtn.id = 'construction-btn';
+  constructionBtn.textContent = 'Construction';
+  Object.assign(constructionBtn.style, { height: squareStyle.height });
+  constructionBtn.addEventListener('click', () => {
+    if (typeof onConstruction === 'function') onConstruction();
+  });
+
   const menuBtn = document.createElement('button');
   menuBtn.id = 'menu-btn';
   menuBtn.textContent = 'Menu';
@@ -117,26 +129,26 @@ export function initTopMenu(onMenu, onBack, onReset) {
   }
   menuBtn.addEventListener('click', () => toggleMenu());
 
-    if (typeof onMenu === 'function') {
-      const jobsBtn = document.createElement('button');
-      jobsBtn.textContent = 'Jobs';
-      Object.assign(jobsBtn.style, { height: squareStyle.height });
-      jobsBtn.addEventListener('click', () => {
-        toggleMenu(false);
-        onMenu();
-        showBackButton(true);
-      });
-      dropdown.appendChild(jobsBtn);
-    }
-
-    const resetBtn = document.createElement('button');
-    resetBtn.textContent = 'New Game';
-    Object.assign(resetBtn.style, { height: squareStyle.height });
-    resetBtn.addEventListener('click', () => {
+  if (typeof onMenu === 'function') {
+    const jobsBtn = document.createElement('button');
+    jobsBtn.textContent = 'Jobs';
+    Object.assign(jobsBtn.style, { height: squareStyle.height });
+    jobsBtn.addEventListener('click', () => {
       toggleMenu(false);
-      if (typeof onReset === 'function') onReset();
+      onMenu();
+      showBackButton(true);
     });
-    dropdown.appendChild(resetBtn);
+    dropdown.appendChild(jobsBtn);
+  }
+
+  const resetBtn = document.createElement('button');
+  resetBtn.textContent = 'New Game';
+  Object.assign(resetBtn.style, { height: squareStyle.height });
+  resetBtn.addEventListener('click', () => {
+    toggleMenu(false);
+    if (typeof onReset === 'function') onReset();
+  });
+  dropdown.appendChild(resetBtn);
 
   const backBtn = document.createElement('button');
   backBtn.id = 'back-btn';
@@ -152,6 +164,7 @@ export function initTopMenu(onMenu, onBack, onReset) {
   bar.appendChild(themeBtn);
   bar.appendChild(zoomOut);
   bar.appendChild(zoomIn);
+  bar.appendChild(constructionBtn);
   bar.appendChild(menuWrapper);
   bar.appendChild(backBtn);
   applyZoom();


### PR DESCRIPTION
## Summary
- mark the settlement's origin tile as open terrain and render a flag icon so the camp is easy to spot
- add a dedicated Construction control to the top menu that opens a modal dashboard for planning and reviewing projects
- show a condensed construction status panel on the main view while keeping the full planner in the modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddb42cf6c88325befdf74372718a0c