### PR TITLE
Improve map control layout responsiveness

### DIFF
--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -973,7 +973,7 @@ export function initGameUI() {
     }
 
     const instructions = document.createElement('p');
-    instructions.textContent = 'Use the arrows or drag across the map to explore. Tap the crosshair to recenter the view.';
+    instructions.textContent = 'Use the arrows or drag across the map to explore. Tap the crosshair to recenter the view and adjust the zoom controls to change scale.';
     mapSection.appendChild(instructions);
 
     mapView = createMapView(mapSection, {

--- a/src/mapView.js
+++ b/src/mapView.js
@@ -20,57 +20,28 @@ function summarizeTerrain(types = []) {
 function computeViewportDimensions(cols = 0, rows = 0) {
   const MIN_SIZE = 220;
   const hasDimensions = cols > 0 && rows > 0;
-  const aspectRatio = hasDimensions ? rows / cols : 1;
 
   if (typeof window === 'undefined') {
     const base = 320;
-    const width = hasDimensions ? base : Math.max(MIN_SIZE, base);
-    const height = hasDimensions
-      ? Math.max(MIN_SIZE, base * aspectRatio)
-      : Math.max(MIN_SIZE, base);
-    return { width, height };
+    const size = Math.max(MIN_SIZE, base);
+    return { width: size, height: size };
   }
 
   const widthAllowance = Math.max(MIN_SIZE, window.innerWidth - 80);
   const heightAllowance = Math.max(MIN_SIZE, window.innerHeight - 260);
+  const limit = Math.min(widthAllowance, heightAllowance);
 
   if (!hasDimensions) {
-    const size = Math.max(MIN_SIZE, Math.min(widthAllowance, heightAllowance));
+    const size = Math.max(MIN_SIZE, limit);
     return { width: size, height: size };
   }
 
-  let width = widthAllowance;
-  let height = width * aspectRatio;
+  const tileWidthLimit = widthAllowance / cols;
+  const tileHeightLimit = heightAllowance / rows;
+  const tileSize = Math.max(8, Math.min(tileWidthLimit, tileHeightLimit));
+  const size = Math.max(MIN_SIZE, Math.min(limit, tileSize * Math.max(cols, rows)));
 
-  if (height > heightAllowance) {
-    height = heightAllowance;
-    width = height / aspectRatio;
-  }
-
-  if (width > widthAllowance) {
-    width = widthAllowance;
-    height = width * aspectRatio;
-  }
-
-  if (height < MIN_SIZE) {
-    height = MIN_SIZE;
-    width = height / aspectRatio;
-    if (width > widthAllowance) {
-      width = widthAllowance;
-      height = Math.max(MIN_SIZE, width * aspectRatio);
-    }
-  }
-
-  if (width < MIN_SIZE) {
-    width = MIN_SIZE;
-    height = width * aspectRatio;
-    if (height > heightAllowance) {
-      height = heightAllowance;
-      width = Math.max(MIN_SIZE, height / aspectRatio);
-    }
-  }
-
-  return { width, height };
+  return { width: size, height: size };
 }
 
 function requestFrame(callback) {
@@ -92,10 +63,20 @@ export function createMapView(container, {
 } = {}) {
   if (!container) throw new Error('Container is required for map view');
 
+  const applySquareButtonStyle = (button, fontSize = '18px') => {
+    button.style.width = '48px';
+    button.style.height = '48px';
+    button.style.fontSize = fontSize;
+    button.style.display = 'flex';
+    button.style.alignItems = 'center';
+    button.style.justifyContent = 'center';
+  };
+
   const state = {
     map: null,
     context: {},
     home: { xStart: 0, yStart: 0 },
+    focus: { x: 0, y: 0 },
     drag: {
       active: false,
       lastX: 0,
@@ -105,7 +86,10 @@ export function createMapView(container, {
     },
     resizeHandler: null,
     fetchMap,
-    onMapUpdate
+    onMapUpdate,
+    zoom: 1,
+    minZoom: 0.5,
+    maxZoom: 3
   };
 
   const mapWrapper = document.createElement('div');
@@ -122,40 +106,187 @@ export function createMapView(container, {
   const mapDisplay = document.createElement('pre');
   mapDisplay.className = `${idPrefix}-display map-display`;
   mapDisplay.style.whiteSpace = 'pre';
-  mapDisplay.style.fontFamily = '"Apple Color Emoji", "Segoe UI Emoji", sans-serif';
+  mapDisplay.style.fontFamily = '"Apple Color Emoji", "Noto Color Emoji", "Segoe UI Emoji", sans-serif';
   mapDisplay.style.lineHeight = '1';
   mapDisplay.style.margin = '0';
   mapDisplay.style.padding = '0';
   mapDisplay.style.display = 'block';
   mapDisplay.style.width = '100%';
   mapDisplay.style.height = '100%';
+  mapDisplay.style.position = 'absolute';
+  mapDisplay.style.top = '50%';
+  mapDisplay.style.left = '50%';
+  mapDisplay.style.transform = 'translate(-50%, -50%) scale(1)';
+  mapDisplay.style.transformOrigin = 'center center';
   mapDisplay.style.boxSizing = 'border-box';
   mapWrapper.appendChild(mapDisplay);
 
-  container.appendChild(mapWrapper);
+  const layoutRoot = document.createElement('div');
+  layoutRoot.className = `${idPrefix}-layout map-layout`;
+  layoutRoot.style.display = 'flex';
+  layoutRoot.style.alignItems = 'flex-start';
+  layoutRoot.style.flexWrap = 'nowrap';
+  layoutRoot.style.gap = '16px';
+
+  const mapContainer = document.createElement('div');
+  mapContainer.className = `${idPrefix}-map-container map-container`;
+  mapContainer.style.display = 'flex';
+  mapContainer.style.flexDirection = 'column';
+  mapContainer.style.alignItems = 'flex-start';
+  mapContainer.style.gap = '12px';
+
+  const sideStack = document.createElement('div');
+  sideStack.className = `${idPrefix}-control-stack map-control-stack`;
+  sideStack.style.display = 'flex';
+  sideStack.style.flexDirection = 'column';
+  sideStack.style.alignItems = 'stretch';
+  sideStack.style.gap = '12px';
+
+  mapContainer.appendChild(mapWrapper);
+  layoutRoot.appendChild(mapContainer);
+  container.appendChild(layoutRoot);
 
   const controls = document.createElement('div');
+  let navGrid = null;
+  let zoomControls = null;
+  let zoomOutButton = null;
+  let zoomInButton = null;
+  let zoomResetButton = null;
   if (showControls) {
     controls.className = `${idPrefix}-controls map-controls`;
-    controls.style.display = 'grid';
-    controls.style.gridTemplateColumns = 'repeat(3, 48px)';
-    controls.style.gridAutoRows = '48px';
-    controls.style.gap = '6px';
-    controls.style.margin = '8px auto 0';
+    controls.style.display = 'flex';
+    controls.style.flexDirection = 'column';
+    controls.style.alignItems = 'center';
+    controls.style.gap = '8px';
     controls.style.justifyContent = 'center';
-    container.appendChild(controls);
+    controls.style.alignSelf = 'flex-start';
+
+    navGrid = document.createElement('div');
+    navGrid.className = `${idPrefix}-nav map-nav-grid`;
+    navGrid.style.display = 'grid';
+    navGrid.style.gridTemplateColumns = 'repeat(3, 48px)';
+    navGrid.style.gridAutoRows = '48px';
+    navGrid.style.gap = '6px';
+    controls.appendChild(navGrid);
+
+    zoomControls = document.createElement('div');
+    zoomControls.className = `${idPrefix}-zoom map-zoom-controls`;
+    zoomControls.style.display = 'flex';
+    zoomControls.style.gap = '8px';
+    zoomControls.style.justifyContent = 'center';
+    zoomControls.style.alignItems = 'center';
+    zoomControls.style.width = '100%';
+
+    const createZoomButton = (label, aria, fontSize) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = label;
+      button.setAttribute('aria-label', aria);
+      applySquareButtonStyle(button, fontSize);
+      return button;
+    };
+
+    zoomOutButton = createZoomButton('−', 'Zoom out', '20px');
+
+    zoomResetButton = createZoomButton('100%', 'Reset zoom to 100%', '16px');
+
+    zoomInButton = createZoomButton('+', 'Zoom in', '20px');
+
+    zoomControls.appendChild(zoomOutButton);
+    zoomControls.appendChild(zoomResetButton);
+    zoomControls.appendChild(zoomInButton);
+    controls.appendChild(zoomControls);
+
+    zoomOutButton.addEventListener('click', () => {
+      zoomBy(-0.2);
+    });
+    zoomInButton.addEventListener('click', () => {
+      zoomBy(0.2);
+    });
+    zoomResetButton.addEventListener('click', () => {
+      resetZoom();
+    });
+
+    updateZoomControls();
   }
 
   let legendList = null;
   let legendTitle = null;
+  let legendContainer = null;
   if (showLegend) {
+    legendContainer = document.createElement('div');
+    legendContainer.className = `${idPrefix}-legend-container map-legend-container`;
+    legendContainer.style.display = 'flex';
+    legendContainer.style.flexDirection = 'column';
+    legendContainer.style.alignItems = 'flex-start';
+    legendContainer.style.gap = '8px';
+    legendContainer.style.alignSelf = 'flex-start';
+
     legendTitle = document.createElement('h4');
     legendTitle.textContent = 'Legend';
-    container.appendChild(legendTitle);
+    legendContainer.appendChild(legendTitle);
 
     legendList = document.createElement('ul');
     legendList.className = `${idPrefix}-legend`;
-    container.appendChild(legendList);
+    legendContainer.appendChild(legendList);
+  }
+
+  function isLandscapeOrientation() {
+    if (typeof window === 'undefined') return true;
+    if (typeof window.matchMedia === 'function') {
+      const portraitQuery = window.matchMedia('(orientation: portrait)');
+      if (portraitQuery && typeof portraitQuery.matches === 'boolean') {
+        return !portraitQuery.matches;
+      }
+    }
+    return window.innerWidth >= window.innerHeight;
+  }
+
+  function applyResponsiveLayout() {
+    const isLandscape = isLandscapeOrientation();
+    const hasControls = showControls && controls;
+    const hasLegend = Boolean(legendContainer);
+    const hasSideContent = hasControls || hasLegend;
+
+    layoutRoot.style.flexWrap = hasSideContent ? 'nowrap' : 'wrap';
+
+    if (isLandscape && hasSideContent) {
+      mapContainer.style.flexDirection = 'row';
+      mapContainer.style.flexWrap = 'nowrap';
+      mapContainer.style.gap = '16px';
+      if (!sideStack.parentElement) {
+        mapContainer.appendChild(sideStack);
+      }
+      if (hasControls) {
+        controls.style.margin = '0';
+        controls.style.alignItems = 'center';
+        controls.style.alignSelf = 'flex-start';
+        controls.style.justifyContent = 'center';
+        sideStack.appendChild(controls);
+      }
+      if (hasLegend) {
+        sideStack.appendChild(legendContainer);
+      }
+    } else {
+      mapContainer.style.flexDirection = 'column';
+      mapContainer.style.flexWrap = 'nowrap';
+      mapContainer.style.gap = '12px';
+      if (sideStack.parentElement) {
+        sideStack.parentElement.removeChild(sideStack);
+      }
+      if (hasControls) {
+        controls.style.margin = '8px 0 0';
+        controls.style.alignItems = 'flex-start';
+        controls.style.alignSelf = 'flex-start';
+        controls.style.justifyContent = 'flex-start';
+        mapContainer.appendChild(controls);
+      }
+      if (hasLegend) {
+        layoutRoot.appendChild(legendContainer);
+      }
+    }
+
+    requestFrame(updateFontSize);
   }
 
   function updateLegend(counts = {}) {
@@ -168,6 +299,63 @@ export function createMapView(container, {
       li.textContent = `${symbol} – ${label} (${amount})`;
       legendList.appendChild(li);
     });
+  }
+
+  function normalizeFocusCoords(coords = {}) {
+    const x = Number.isFinite(coords.x) ? coords.x : 0;
+    const y = Number.isFinite(coords.y) ? coords.y : 0;
+    return { x, y };
+  }
+
+  function computeHomeStart(coords = {}) {
+    const rows = state.map?.tiles?.length || 0;
+    const cols = rows ? state.map.tiles[0]?.length || 0 : 0;
+    if (!rows || !cols) {
+      return { xStart: state.map?.xStart || 0, yStart: state.map?.yStart || 0 };
+    }
+    const focus = normalizeFocusCoords(coords);
+    const halfCols = Math.floor(cols / 2);
+    const halfRows = Math.floor(rows / 2);
+    return {
+      xStart: Math.round(focus.x) - halfCols,
+      yStart: Math.round(focus.y) - halfRows
+    };
+  }
+
+  function updateZoomControls() {
+    if (!zoomResetButton) return;
+    zoomResetButton.textContent = `${Math.round(state.zoom * 100)}%`;
+    zoomResetButton.setAttribute('aria-label', `Reset zoom to 100% (current ${Math.round(state.zoom * 100)}%)`);
+    if (zoomOutButton) {
+      zoomOutButton.disabled = state.zoom <= state.minZoom + 0.001;
+    }
+    if (zoomInButton) {
+      zoomInButton.disabled = state.zoom >= state.maxZoom - 0.001;
+    }
+  }
+
+  function applyZoomTransform() {
+    mapDisplay.style.transform = `translate(-50%, -50%) scale(${state.zoom})`;
+    updateZoomControls();
+  }
+
+  function setZoom(nextZoom) {
+    const clamped = Math.min(state.maxZoom, Math.max(state.minZoom, nextZoom));
+    if (Math.abs(clamped - state.zoom) < 0.001) {
+      updateZoomControls();
+      return;
+    }
+    state.zoom = clamped;
+    applyZoomTransform();
+    requestFrame(updateFontSize);
+  }
+
+  function zoomBy(delta) {
+    setZoom(state.zoom + delta);
+  }
+
+  function resetZoom() {
+    setZoom(1);
   }
 
   function updateFontSize() {
@@ -200,6 +388,10 @@ export function createMapView(container, {
   function applyMap(nextMap) {
     if (!nextMap || !nextMap.tiles) return;
     state.map = { ...nextMap };
+    if (state.focus) {
+      state.home = computeHomeStart(state.focus);
+    }
+    state.context = { ...state.context, focus: { ...state.focus } };
     if (typeof state.onMapUpdate === 'function') {
       state.onMapUpdate(state.map, state.context);
     }
@@ -264,7 +456,7 @@ export function createMapView(container, {
   }
 
   function attachNavButtons() {
-    if (!showControls) return;
+    if (!showControls || !navGrid) return;
     const navButtons = [
       { label: '↖', dx: -1, dy: -1, aria: 'Pan northwest' },
       { label: '↑', dx: 0, dy: -1, aria: 'Pan north' },
@@ -281,12 +473,7 @@ export function createMapView(container, {
       btn.type = 'button';
       btn.textContent = config.label;
       btn.setAttribute('aria-label', config.aria);
-      btn.style.width = '48px';
-      btn.style.height = '48px';
-      btn.style.fontSize = '18px';
-      btn.style.display = 'flex';
-      btn.style.alignItems = 'center';
-      btn.style.justifyContent = 'center';
+      applySquareButtonStyle(btn);
       btn.addEventListener('click', () => {
         if (config.recenter) {
           centerMap();
@@ -294,7 +481,7 @@ export function createMapView(container, {
           pan(config.dx, config.dy);
         }
       });
-      controls.appendChild(btn);
+      navGrid.appendChild(btn);
     });
   }
 
@@ -375,11 +562,14 @@ export function createMapView(container, {
   }
 
   const detachGlobalDrag = attachDragHandlers();
+  applyZoomTransform();
   attachNavButtons();
+  applyResponsiveLayout();
 
   if (typeof window !== 'undefined') {
     state.resizeHandler = () => {
       updateWrapperSize();
+      applyResponsiveLayout();
     };
     window.addEventListener('resize', state.resizeHandler);
   }
@@ -388,17 +578,35 @@ export function createMapView(container, {
     setMap(map, context = {}) {
       state.map = map ? { ...map } : null;
       state.context = { ...state.context, ...context };
-      if (state.map) {
-        state.home = {
-          xStart: state.map.xStart || 0,
-          yStart: state.map.yStart || 0
-        };
+      if (!state.map) {
+        render();
+        return;
       }
-      render();
+
+      const focusCandidate =
+        context?.focus ??
+        context?.center ??
+        context?.current ??
+        context?.currentCoords ??
+        context?.homeCoords ??
+        state.focus;
+      state.focus = normalizeFocusCoords(focusCandidate);
+      state.context = { ...state.context, focus: { ...state.focus } };
+      state.home = computeHomeStart(state.focus);
+
+      const needsRecentering =
+        state.map.xStart !== state.home.xStart || state.map.yStart !== state.home.yStart;
+
+      if (needsRecentering) {
+        requestMapUpdate(state.home.xStart, state.home.yStart);
+      } else {
+        render();
+      }
     },
     refresh() {
       updateWrapperSize();
       updateFontSize();
+      applyResponsiveLayout();
     },
     center: centerMap,
     destroy() {
@@ -408,16 +616,18 @@ export function createMapView(container, {
         }
         if (detachGlobalDrag) detachGlobalDrag();
       }
-      if (mapWrapper.parentElement === container) container.removeChild(mapWrapper);
-      if (showControls && controls.parentElement === container) container.removeChild(controls);
-      if (legendList && legendList.parentElement === container) container.removeChild(legendList);
-      if (legendTitle && legendTitle.parentElement === container) container.removeChild(legendTitle);
+      if (layoutRoot.parentElement) {
+        layoutRoot.parentElement.removeChild(layoutRoot);
+      }
     },
     elements: {
+      layout: layoutRoot,
+      mapContainer,
       wrapper: mapWrapper,
       display: mapDisplay,
       controls,
-      legendList
+      legendList,
+      legendContainer
     }
   };
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -58,7 +58,7 @@ export function initSetupUI(onStart) {
   mapSection.style.marginTop = '12px';
 
   const mapIntro = document.createElement('p');
-  mapIntro.textContent = 'Preview of the surrounding area rendered with emoji terrain symbols. Each icon represents one patch of terrain.';
+  mapIntro.textContent = 'Preview of the surrounding area rendered with emoji terrain symbols. Each icon represents one patch of terrain. Use the navigation and zoom controls to examine different parts of the map.';
   mapSection.appendChild(mapIntro);
 
   const seedRow = document.createElement('div');


### PR DESCRIPTION
## Summary
- wrap the map UI in a layout container so the navigation/zoom controls can live beside or below the viewport
- detect window orientation to shift the control stack and legend between side-by-side and stacked arrangements while keeping the legend aligned correctly
- add Noto Color Emoji to the font stack so terrain icons reliably render across platforms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddd4f2e30083259c3b15764e4c8271