### PR TITLE
Add profile/log overlays and responsive layout updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,38 @@
       --map-bg: #3a3a3a;
       --map-border: #555;
     }
+    * {
+      box-sizing: border-box;
+    }
     body {
       background: var(--bg-color);
       color: var(--text-color);
+      font-family: 'Segoe UI', Roboto, sans-serif;
+      margin: 0;
+      min-height: 100vh;
     }
     #top-menu, #bottom-menu {
       background: var(--menu-bg);
+      z-index: 1000;
+    }
+    #content {
+      width: min(100%, 1200px);
+      margin: 0 auto;
+      padding: clamp(56px, 8vh, 96px) 16px clamp(72px, 12vh, 128px);
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+      min-height: 100vh;
+    }
+    #game {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 16px;
+      align-items: start;
+      width: 100%;
+    }
+    #game > * {
+      min-width: 0;
     }
     .map-wrapper {
       border: 1px solid var(--map-border);
@@ -34,12 +60,20 @@
       background: var(--map-bg);
       color: var(--text-color);
     }
+    @media (max-width: 768px) {
+      #content {
+        padding: clamp(56px, 12vh, 88px) 12px clamp(72px, 16vh, 140px);
+        gap: 16px;
+      }
+      #game {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
   </style>
 </head>
 <body class="light">
   <div id="top-menu"></div>
-  <div id="content" style="margin-top:40px;">
-    <h1>Fantasy Survival</h1>
+  <div id="content">
     <div id="setup"></div>
     <div id="game" style="display:none;"></div>
   </div>

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,6 +1,6 @@
 const RESOURCE_ICON_MAP = {
   wood: { icon: '🪵', label: 'Wood' },
-  firewood: { icon: '🔥', label: 'Firewood' },
+  firewood: { icon: '🪵', label: 'Firewood' },
   food: { icon: '🍲', label: 'Food Rations' },
   hides: { icon: '🦬', label: 'Animal Hides' },
   'small stones': { icon: '🪨', label: 'Small Stones' },

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,14 @@ import { calculateStartingGoods, harvestWood } from './resources.js';
 import { initSetupUI } from './ui.js';
 import { saveGame, loadGame, clearSave } from './persistence.js';
 import { difficultySettings } from './difficulty.js';
-import { initGameUI, showJobs, closeJobs, showConstructionDashboard } from './gameUI.js';
+import {
+  initGameUI,
+  showJobs,
+  closeJobs,
+  showConstructionDashboard,
+  showProfilePopup,
+  showLogPopup
+} from './gameUI.js';
 import { initTopMenu, initBottomMenu } from './menu.js';
 import { resetToDawn } from './time.js';
 import { resetOrders } from './orders.js';
@@ -56,7 +63,7 @@ function init() {
   initTopMenu(showJobs, closeJobs, () => {
     clearSave();
     window.location.reload();
-  }, showConstructionDashboard);
+  }, showConstructionDashboard, showProfilePopup, showLogPopup);
   initBottomMenu();
   if (!loadGame()) {
     initSetupUI(startGame);

--- a/src/menu.js
+++ b/src/menu.js
@@ -27,7 +27,7 @@ export function showBackButton(show) {
   }
 }
 
-export function initTopMenu(onMenu, onBack, onReset, onConstruction) {
+export function initTopMenu(onMenu, onBack, onReset, onConstruction, onProfile, onLog) {
   const bar = document.getElementById('top-menu');
   if (!bar) return;
   applyTheme();
@@ -128,6 +128,28 @@ export function initTopMenu(onMenu, onBack, onReset, onConstruction) {
     }
   }
   menuBtn.addEventListener('click', () => toggleMenu());
+
+  if (typeof onProfile === 'function') {
+    const profileBtn = document.createElement('button');
+    profileBtn.textContent = 'Profile';
+    Object.assign(profileBtn.style, { height: squareStyle.height });
+    profileBtn.addEventListener('click', () => {
+      toggleMenu(false);
+      onProfile();
+    });
+    dropdown.appendChild(profileBtn);
+  }
+
+  if (typeof onLog === 'function') {
+    const logBtn = document.createElement('button');
+    logBtn.textContent = 'Log';
+    Object.assign(logBtn.style, { height: squareStyle.height });
+    logBtn.addEventListener('click', () => {
+      toggleMenu(false);
+      onLog();
+    });
+    dropdown.appendChild(logBtn);
+  }
 
   if (typeof onMenu === 'function') {
     const jobsBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- remove the landing header and update the layout styles so the game content scales with the viewport
- add Profile and Log popups that surface settlement details and the event history from the menu instead of the main dashboard
- update the map viewport sizing logic for a width-driven 1:1 scale and switch the firewood icon to a wood glyph

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df2bd333488325a767df7583c2e05c