### PR TITLE
Revamp map view and time display

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,27 @@
       gap: 24px;
       min-height: 100vh;
     }
+    #time-banner {
+      width: 100%;
+      background: var(--menu-bg);
+      border: 1px solid var(--map-border);
+      border-radius: 12px;
+      padding: 10px 16px;
+      font-weight: 600;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+    #time-banner .time-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: var(--bg-color);
+      border: 1px solid var(--map-border);
+    }
     #game {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ import {
   showLogPopup
 } from './gameUI.js';
 import { initTopMenu, initBottomMenu } from './menu.js';
-import { resetToDawn } from './time.js';
+import { resetToDawn, getSeasonDetails, getSeasonForMonth } from './time.js';
 import { resetOrders } from './orders.js';
 
 function startGame(settings = {}) {
@@ -31,8 +31,19 @@ function startGame(settings = {}) {
   const startingGoods = calculateStartingGoods(cfg);
   Object.entries(startingGoods).forEach(([item, qty]) => addItem(item, qty));
 
-  if (settings.season) store.time.season = settings.season;
   store.time.day = 1;
+  store.time.month = 1;
+  store.time.year = 1;
+  store.time.weather = 'Clear';
+  if (settings.season) {
+    store.time.season = settings.season;
+    const seasonInfo = getSeasonDetails(settings.season);
+    if (seasonInfo.months?.length) {
+      store.time.month = seasonInfo.months[0];
+    }
+  } else {
+    store.time.season = getSeasonForMonth(store.time.month);
+  }
   resetToDawn();
   if (settings.biome) {
     generateLocation('loc1', settings.biome, store.time.season, settings.seed);

--- a/src/mapView.js
+++ b/src/mapView.js
@@ -7,6 +7,8 @@ const LEGEND_DEFAULTS = {
   ore: 'Ore Deposits'
 };
 
+const MAP_SCALE_FACTOR = 1.5;
+
 function summarizeTerrain(types = []) {
   const counts = { water: 0, open: 0, forest: 0, ore: 0 };
   types.forEach(row => {
@@ -23,8 +25,9 @@ function computeViewportDimensions(cols = 0, rows = 0, availableWidth = null) {
 
   if (typeof window === 'undefined') {
     const base = 320;
-    const size = Math.max(MIN_SIZE, base);
-    return { width: size, height: size };
+    const size = Math.max(MIN_SIZE, base) * MAP_SCALE_FACTOR;
+    const rounded = Math.round(size);
+    return { width: rounded, height: rounded };
   }
 
   const widthAllowance = Math.max(
@@ -35,7 +38,12 @@ function computeViewportDimensions(cols = 0, rows = 0, availableWidth = null) {
   const fallbackSize = Math.max(MIN_SIZE, Math.min(widthAllowance, heightAllowance));
 
   if (!hasDimensions) {
-    return { width: fallbackSize, height: fallbackSize };
+    const scaledFallback = Math.max(
+      MIN_SIZE,
+      Math.min(widthAllowance, heightAllowance, fallbackSize * MAP_SCALE_FACTOR)
+    );
+    const rounded = Math.round(scaledFallback);
+    return { width: rounded, height: rounded };
   }
 
   const tileWidthLimit = widthAllowance / cols;
@@ -43,9 +51,14 @@ function computeViewportDimensions(cols = 0, rows = 0, availableWidth = null) {
   const tileSize = Math.max(1, Math.min(tileWidthLimit, tileHeightLimit));
   const width = Math.max(MIN_SIZE, Math.min(widthAllowance, tileSize * cols));
   const height = Math.max(MIN_SIZE, Math.min(heightAllowance, tileSize * rows));
-  const squareSize = Math.max(MIN_SIZE, Math.min(fallbackSize, Math.min(width, height)));
+  const baseSquare = Math.max(MIN_SIZE, Math.min(fallbackSize, Math.min(width, height)));
+  const scaledSquare = Math.max(
+    MIN_SIZE,
+    Math.min(widthAllowance, heightAllowance, baseSquare * MAP_SCALE_FACTOR)
+  );
+  const rounded = Math.round(scaledSquare);
 
-  return { width: squareSize, height: squareSize };
+  return { width: rounded, height: rounded };
 }
 
 function requestFrame(callback) {
@@ -175,11 +188,14 @@ export function createMapView(container, {
 
     zoomControls = document.createElement('div');
     zoomControls.className = `${idPrefix}-zoom map-zoom-controls`;
-    zoomControls.style.display = 'flex';
-    zoomControls.style.gap = '8px';
+    zoomControls.style.display = 'grid';
+    zoomControls.style.gridTemplateColumns = 'repeat(3, 48px)';
+    zoomControls.style.gridAutoRows = '48px';
+    zoomControls.style.gap = '6px';
     zoomControls.style.justifyContent = 'center';
     zoomControls.style.alignItems = 'center';
-    zoomControls.style.width = '100%';
+    zoomControls.style.justifyItems = 'center';
+    zoomControls.style.alignContent = 'center';
 
     const createZoomButton = (label, aria, fontSize) => {
       const button = document.createElement('button');

--- a/src/state.js
+++ b/src/state.js
@@ -5,7 +5,7 @@ class DataStore {
     this.inventory = new Map();
     this.locations = new Map();
     this.technologies = new Map();
-    this.time = { day: 0, hour: 6, season: 'Spring' };
+    this.time = { day: 1, month: 1, year: 1, hour: 6, season: 'Spring', weather: 'Clear' };
     this.difficulty = 'normal';
     this.jobs = {};
     this.orders = [];
@@ -70,7 +70,16 @@ class DataStore {
     this.inventory = new Map(data.inventory || []);
     this.locations = new Map(data.locations || []);
     this.technologies = new Map(data.technologies || []);
-    this.time = { day: 0, hour: 6, season: 'Spring', ...(data.time || {}) };
+    const savedTime = data.time || {};
+    this.time = {
+      day: 1,
+      month: 1,
+      year: 1,
+      hour: 6,
+      season: 'Spring',
+      weather: 'Clear',
+      ...savedTime
+    };
     this.difficulty = data.difficulty || 'normal';
     this.jobs = data.jobs || {};
     this.orders = data.orders || [];

--- a/src/time.js
+++ b/src/time.js
@@ -1,42 +1,170 @@
 import store from './state.js';
 
-const seasons = ['Spring', 'Summer', 'Autumn', 'Winter'];
+export const DAYS_PER_MONTH = 28;
+export const MONTHS_PER_YEAR = 13;
 const HOURS_PER_DAY = 24;
 const DAWN_HOUR = 6;
 
-export function advanceDay() {
-  store.time.day += 1;
-  if (store.time.day % 90 === 0) {
-    const index = seasons.indexOf(store.time.season);
-    store.time.season = seasons[(index + 1) % seasons.length];
+const SEASON_DETAILS = {
+  Spring: { icon: '🌱', months: [1, 2, 3] },
+  Summer: { icon: '☀️', months: [4, 5, 6] },
+  Autumn: { icon: '🍂', months: [7, 8, 9] },
+  Winter: { icon: '❄️', months: [10, 11, 12, 13] }
+};
+
+const WEATHER_PATTERNS = [
+  { name: 'Clear', icon: '☀️', weights: { Spring: 3, Summer: 4, Autumn: 3, Winter: 2 } },
+  { name: 'Cloudy', icon: '☁️', weights: { Spring: 2, Summer: 2, Autumn: 3, Winter: 3 } },
+  { name: 'Rain', icon: '🌧️', weights: { Spring: 3, Summer: 3, Autumn: 2, Winter: 1 } },
+  { name: 'Storm', icon: '⛈️', weights: { Spring: 1, Summer: 2, Autumn: 1, Winter: 1 } },
+  { name: 'Snow', icon: '❄️', weights: { Spring: 0, Summer: 0, Autumn: 1, Winter: 4 } },
+  { name: 'Fog', icon: '🌫️', weights: { Spring: 1, Summer: 1, Autumn: 2, Winter: 2 } }
+];
+
+const DAY_PERIODS = [
+  { key: 'night', label: 'Night', icon: '🌙', start: 0, end: 4 },
+  { key: 'dawn', label: 'Dawn', icon: '🌅', start: 4, end: 7 },
+  { key: 'day', label: 'Day', icon: '☀️', start: 7, end: 18 },
+  { key: 'dusk', label: 'Dusk', icon: '🌇', start: 18, end: 21 },
+  { key: 'night', label: 'Night', icon: '🌙', start: 21, end: 24 }
+];
+
+function normalizeHour(hour = 0) {
+  const normalized = Number.isFinite(hour) ? hour : 0;
+  return ((normalized % HOURS_PER_DAY) + HOURS_PER_DAY) % HOURS_PER_DAY;
+}
+
+function ensureTimeStructure() {
+  if (!store.time) {
+    store.time = {};
   }
+  if (!Number.isFinite(store.time.day) || store.time.day < 1) {
+    store.time.day = 1;
+  }
+  if (!Number.isFinite(store.time.month) || store.time.month < 1) {
+    store.time.month = 1;
+  }
+  if (!Number.isFinite(store.time.year) || store.time.year < 1) {
+    store.time.year = 1;
+  }
+  if (!Number.isFinite(store.time.hour)) {
+    store.time.hour = DAWN_HOUR;
+  }
+  store.time.season = getSeasonForMonth(store.time.month);
+  if (!store.time.weather) {
+    store.time.weather = 'Clear';
+  }
+  return store.time;
+}
+
+export function getSeasonForMonth(month = 1) {
+  const base = Number.isFinite(month) ? Math.floor(month) : 1;
+  const normalized = ((base - 1) % MONTHS_PER_YEAR + MONTHS_PER_YEAR) % MONTHS_PER_YEAR + 1;
+  return (
+    Object.entries(SEASON_DETAILS).find(([, details]) => details.months.includes(normalized))?.[0] || 'Spring'
+  );
+}
+
+function chooseWeather(season, previous) {
+  const options = WEATHER_PATTERNS.map(pattern => ({
+    name: pattern.name,
+    icon: pattern.icon,
+    weight: pattern.weights?.[season] ?? 0
+  })).filter(option => option.weight > 0);
+
+  if (!options.length) {
+    return previous || 'Clear';
+  }
+
+  if (previous) {
+    const prior = options.find(option => option.name === previous);
+    if (prior) {
+      prior.weight += 1.5;
+    }
+  }
+
+  const totalWeight = options.reduce((sum, option) => sum + option.weight, 0);
+  if (totalWeight <= 0) {
+    return previous || options[0].name;
+  }
+
+  let roll = Math.random() * totalWeight;
+  for (const option of options) {
+    roll -= option.weight;
+    if (roll <= 0) {
+      return option.name;
+    }
+  }
+
+  return options[options.length - 1].name;
+}
+
+export function getSeasonDetails(season) {
+  const name = season || 'Unknown';
+  const details = SEASON_DETAILS[name];
+  if (!details) {
+    return { name, icon: '❔', months: [] };
+  }
+  return { name, icon: details.icon, months: [...details.months] };
+}
+
+export function getWeatherDetails(condition) {
+  const entry = WEATHER_PATTERNS.find(pattern => pattern.name === condition);
+  if (!entry) {
+    return { name: condition || 'Unknown', icon: '❔' };
+  }
+  return { name: entry.name, icon: entry.icon };
+}
+
+export function getDayPeriod(hour = store.time?.hour) {
+  const normalized = normalizeHour(hour);
+  const period = DAY_PERIODS.find(p => normalized >= p.start && normalized < p.end) || DAY_PERIODS[0];
+  return { key: period.key, label: period.label, icon: period.icon, start: period.start, end: period.end };
+}
+
+export function advanceDay() {
+  const time = ensureTimeStructure();
+  time.day += 1;
+  if (time.day > DAYS_PER_MONTH) {
+    time.day = 1;
+    time.month += 1;
+    if (time.month > MONTHS_PER_YEAR) {
+      time.month = 1;
+      time.year += 1;
+    }
+  }
+  time.season = getSeasonForMonth(time.month);
+  time.weather = chooseWeather(time.season, time.weather);
 }
 
 export function advanceHours(hours = 1) {
+  const time = ensureTimeStructure();
   const increment = Math.max(0, Number.isFinite(hours) ? hours : 0);
-  store.time.hour += increment;
-  while (store.time.hour >= HOURS_PER_DAY) {
-    store.time.hour -= HOURS_PER_DAY;
+  time.hour += increment;
+  while (time.hour >= HOURS_PER_DAY) {
+    time.hour -= HOURS_PER_DAY;
     advanceDay();
   }
 }
 
 export function info() {
-  return { ...store.time };
+  const time = ensureTimeStructure();
+  return { ...time };
 }
 
-// Provide a backwards-compatible alias for modules that import `timeInfo`.
-// This is useful for legacy code that still expects the older export name.
 export { info as timeInfo };
 
 export function resetToDawn() {
-  store.time.hour = DAWN_HOUR;
+  const time = ensureTimeStructure();
+  time.hour = DAWN_HOUR;
 }
 
 export function isMealTime() {
-  return store.time.hour === 12;
+  const time = ensureTimeStructure();
+  return Math.floor(normalizeHour(time.hour)) === 12;
 }
 
 export function isNightfall() {
-  return store.time.hour >= 20;
+  const time = ensureTimeStructure();
+  return normalizeHour(time.hour) >= 20;
 }


### PR DESCRIPTION
## Summary
- enlarge the map viewport by 50% and align the zoom controls with the navigation buttons
- move the time banner beneath the top menu and restyle it to show calendar, season, weather, and day period icons
- implement a 13-month calendar with daily weather generation and update the event log to the new format

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68df34b279548325bc189b4e9b956d1f