### PR TITLE
Center spawn point and improve map emoji rendering

### DIFF
--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -282,10 +282,10 @@ function renderEventLog() {
     const li = document.createElement('li');
     const dayText = padNumber(entry.day ?? 1);
     const monthText = padNumber(entry.month ?? 1);
-    const yearText = entry.year ?? 1;
+    const yearText = padNumber(entry.year ?? 1);
     const descriptorParts = [entry.season, entry.weather].filter(Boolean);
     const descriptor = descriptorParts.length ? ` (${descriptorParts.join(' • ')})` : '';
-    li.textContent = `Day ${dayText} / Month ${monthText} / Year ${yearText}${descriptor} – ${formatHour(entry.hour)} – ${entry.message}`;
+    li.textContent = `${dayText}/${monthText}/${yearText}${descriptor} – ${formatHour(entry.hour)} – ${entry.message}`;
     eventLogList.appendChild(li);
   });
 }
@@ -904,21 +904,23 @@ function renderTimeBanner() {
   const seasonDetails = getSeasonDetails(t.season);
   const weatherDetails = getWeatherDetails(t.weather);
   const dayPeriod = getDayPeriod(t.hour);
+  const yearText = padNumber(t.year, 2);
+  const dateText = `${padNumber(t.day)}/${padNumber(t.month)}/${yearText}`;
 
   const chips = [
     {
       icon: '🗓️',
-      text: `Day ${padNumber(t.day)} / Month ${padNumber(t.month)} / Year ${t.year}`,
-      title: 'Current date'
+      text: dateText,
+      title: `Current date: ${dateText}`
     },
     {
       icon: seasonDetails.icon,
-      text: seasonDetails.name,
+      text: '',
       title: `${seasonDetails.name} season`
     },
     {
       icon: weatherDetails.icon,
-      text: weatherDetails.name,
+      text: '',
       title: `Weather: ${weatherDetails.name}`
     },
     {
@@ -934,10 +936,12 @@ function renderTimeBanner() {
     if (chip.title) chipEl.title = chip.title;
     const iconEl = document.createElement('span');
     iconEl.textContent = chip.icon;
-    const textEl = document.createElement('span');
-    textEl.textContent = chip.text;
     chipEl.appendChild(iconEl);
-    chipEl.appendChild(textEl);
+    if (chip.text !== undefined && chip.text !== null && chip.text !== '') {
+      const textEl = document.createElement('span');
+      textEl.textContent = chip.text;
+      chipEl.appendChild(textEl);
+    }
     banner.appendChild(chipEl);
   });
 }

--- a/src/location.js
+++ b/src/location.js
@@ -1,12 +1,15 @@
 import store from './state.js';
 import { getBiome } from './biomes.js';
 import { generatePointsOfInterest } from './pointsOfInterest.js';
-import { generateColorMap } from './map.js';
+import { computeCenteredStart, DEFAULT_MAP_HEIGHT, DEFAULT_MAP_WIDTH, generateColorMap } from './map.js';
 
 export function generateLocation(id, biome, season = store.time.season, seed = Date.now()) {
   const features = getBiome(biome)?.features || [];
   const pointsOfInterest = generatePointsOfInterest(biome);
-  const map = generateColorMap(biome, seed, 0, 0, 80, 40, season);
+  const width = DEFAULT_MAP_WIDTH;
+  const height = DEFAULT_MAP_HEIGHT;
+  const { xStart, yStart } = computeCenteredStart(width, height);
+  const map = generateColorMap(biome, seed, xStart, yStart, width, height, season);
   const location = { id, biome, features, pointsOfInterest, map };
   store.addItem('locations', location);
   return location;

--- a/src/mapView.js
+++ b/src/mapView.js
@@ -52,13 +52,21 @@ function computeViewportDimensions(cols = 0, rows = 0, availableWidth = null) {
   const width = Math.max(MIN_SIZE, Math.min(widthAllowance, tileSize * cols));
   const height = Math.max(MIN_SIZE, Math.min(heightAllowance, tileSize * rows));
   const baseSquare = Math.max(MIN_SIZE, Math.min(fallbackSize, Math.min(width, height)));
-  const scaledSquare = Math.max(
+  const scaledSide = Math.max(
     MIN_SIZE,
     Math.min(widthAllowance, heightAllowance, baseSquare * MAP_SCALE_FACTOR)
   );
-  const rounded = Math.round(scaledSquare);
+  const dominant = Math.max(cols, rows) || 1;
+  const tileScale = scaledSide / dominant;
+  const minWidth = Math.round((MIN_SIZE * cols) / dominant);
+  const minHeight = Math.round((MIN_SIZE * rows) / dominant);
+  const derivedWidth = Math.max(minWidth, Math.round(tileScale * cols));
+  const derivedHeight = Math.max(minHeight, Math.round(tileScale * rows));
 
-  return { width: rounded, height: rounded };
+  return {
+    width: Math.max(1, Math.min(widthAllowance, derivedWidth)),
+    height: Math.max(1, Math.min(heightAllowance, derivedHeight))
+  };
 }
 
 function requestFrame(callback) {
@@ -137,6 +145,19 @@ export function createMapView(container, {
   mapDisplay.style.transformOrigin = 'center center';
   mapDisplay.style.boxSizing = 'border-box';
   mapWrapper.appendChild(mapDisplay);
+
+  const iconPreloader = document.createElement('div');
+  iconPreloader.setAttribute('aria-hidden', 'true');
+  iconPreloader.style.position = 'absolute';
+  iconPreloader.style.opacity = '0';
+  iconPreloader.style.pointerEvents = 'none';
+  iconPreloader.style.fontSize = '1px';
+  iconPreloader.style.lineHeight = '1';
+  iconPreloader.style.whiteSpace = 'nowrap';
+  iconPreloader.style.height = '0';
+  iconPreloader.style.overflow = 'hidden';
+  iconPreloader.textContent = `${Object.values(TERRAIN_SYMBOLS).join('')}🚩`;
+  mapWrapper.appendChild(iconPreloader);
 
   const layoutRoot = document.createElement('div');
   layoutRoot.className = `${idPrefix}-layout map-layout`;

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,7 +5,13 @@
 
 import { biomes, getBiome } from './biomes.js';
 import { difficulties, difficultySettings } from './difficulty.js';
-import { generateColorMap, TERRAIN_SYMBOLS } from './map.js';
+import {
+  computeCenteredStart,
+  DEFAULT_MAP_HEIGHT,
+  DEFAULT_MAP_WIDTH,
+  generateColorMap,
+  TERRAIN_SYMBOLS
+} from './map.js';
 import { createMapView } from './mapView.js';
 
 const seasons = ['Spring', 'Summer', 'Autumn', 'Winter'];
@@ -158,13 +164,16 @@ export function initSetupUI(onStart) {
   }
 
   function generatePreview() {
+    const width = DEFAULT_MAP_WIDTH;
+    const height = DEFAULT_MAP_HEIGHT;
+    const { xStart, yStart } = computeCenteredStart(width, height);
     mapData = generateColorMap(
       biomeSelect.select.value,
       mapSeed,
-      0,
-      0,
-      80,
-      40,
+      xStart,
+      yStart,
+      width,
+      height,
       seasonSelect.select.value
     );
     renderMapPreview();


### PR DESCRIPTION
## Summary
- center newly generated locations on the 0,0 spawn tile and reuse shared map sizing helpers
- resize the map viewport to the emoji grid’s aspect ratio and preload terrain icons to avoid blank renders while moving
- streamline time banner and log formatting to remove redundant labels around dates, seasons, and weather

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df4df261988325939108337644e3c3