### PR TITLE
Refine map UI presentation

### DIFF
--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -933,17 +933,20 @@ function renderTimeBanner() {
     {
       icon: dayPeriod.icon,
       text: dateDisplay,
-      title: `${dayPeriod.label} at ${readableTime} on ${dayNumber} ${monthDisplay}, Year ${yearNumber}`
+      title: `${dayPeriod.label} at ${readableTime} on ${dayNumber} ${monthDisplay}, Year ${yearNumber}`,
+      showText: true
     },
     {
       icon: seasonDetails.icon,
       text: seasonDetails.name,
-      title: `${seasonDetails.name} season`
+      title: `${seasonDetails.name} season`,
+      showText: false
     },
     {
       icon: weatherDetails.icon,
       text: weatherDetails.name,
-      title: `Weather: ${weatherDetails.name}`
+      title: `Weather: ${weatherDetails.name}`,
+      showText: false
     }
   ];
 
@@ -951,10 +954,14 @@ function renderTimeBanner() {
     const chipEl = document.createElement('span');
     chipEl.className = 'time-chip';
     if (chip.title) chipEl.title = chip.title;
+    if (chip.title || chip.text) {
+      chipEl.setAttribute('aria-label', chip.title || chip.text);
+    }
     const iconEl = document.createElement('span');
     iconEl.textContent = chip.icon;
     chipEl.appendChild(iconEl);
-    if (chip.text !== undefined && chip.text !== null && chip.text !== '') {
+    const shouldShowText = chip.showText !== false;
+    if (shouldShowText && chip.text !== undefined && chip.text !== null && chip.text !== '') {
       const textEl = document.createElement('span');
       textEl.textContent = chip.text;
       chipEl.appendChild(textEl);

--- a/src/map.js
+++ b/src/map.js
@@ -6,7 +6,7 @@ export const DEFAULT_MAP_WIDTH = DEFAULT_MAP_SIZE;
 export const DEFAULT_MAP_HEIGHT = DEFAULT_MAP_SIZE;
 
 export const TERRAIN_SYMBOLS = {
-  water: '🌊',
+  water: '💧',
   open: '🌾',
   forest: '🌲',
   ore: '⛏️'


### PR DESCRIPTION
## Summary
- adjust the map rendering container and sizing logic so terrain icons render across the full grid at any zoom level
- restyle map navigation controls to match the time banner chips and simplify the legend with tooltip counts and a droplet water icon
- hide the season and weather labels from the time banner while preserving their tooltips and accessibility labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff19cbb8c83258e5a5fbcc88539ba