### PR TITLE
Fix map edge rendering and align HUD banner with map layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,8 @@
       z-index: 1000;
     }
     #content {
-      width: min(100%, 1200px);
+      width: 100%;
+      max-width: 1024px;
       margin: 0 auto;
       padding: clamp(56px, 8vh, 96px) 16px clamp(72px, 12vh, 128px);
       display: flex;
@@ -42,25 +43,32 @@
       min-height: 100vh;
     }
     #time-banner {
-      width: 100%;
+      width: min(100%, var(--map-layout-width, 100%));
       background: var(--menu-bg);
       border: 1px solid var(--map-border);
       border-radius: 12px;
-      padding: 10px 16px;
+      padding: 10px 20px;
       font-weight: 600;
       display: flex;
       flex-wrap: wrap;
-      gap: 8px;
+      gap: 12px;
       align-items: center;
+      margin: 0;
     }
     #time-banner .time-chip {
       display: inline-flex;
       align-items: center;
-      gap: 6px;
-      padding: 4px 10px;
-      border-radius: 999px;
-      background: var(--bg-color);
-      border: 1px solid var(--map-border);
+      gap: 8px;
+      padding: 0;
+      border-radius: 0;
+      background: none;
+      border: none;
+    }
+    #time-banner .time-chip span:first-child {
+      font-size: 1.1em;
+    }
+    #time-banner .time-chip span:last-child {
+      font-weight: 500;
     }
     #game {
       display: grid;

--- a/src/mapView.js
+++ b/src/mapView.js
@@ -410,14 +410,15 @@ export function createMapView(container, {
   mapWrapper.style.touchAction = allowDrag ? 'none' : 'auto';
   mapWrapper.style.boxSizing = 'border-box';
   mapWrapper.style.aspectRatio = '1 / 1';
+  mapWrapper.style.flexShrink = '0';
 
   const mapCanvas = document.createElement('div');
   mapCanvas.className = `${idPrefix}-canvas map-canvas`;
   mapCanvas.style.position = 'absolute';
   mapCanvas.style.inset = '0';
   mapCanvas.style.display = 'flex';
-  mapCanvas.style.alignItems = 'center';
-  mapCanvas.style.justifyContent = 'center';
+  mapCanvas.style.alignItems = 'flex-start';
+  mapCanvas.style.justifyContent = 'flex-start';
   mapCanvas.style.boxSizing = 'border-box';
   mapWrapper.appendChild(mapCanvas);
 
@@ -465,6 +466,8 @@ export function createMapView(container, {
   mapContainer.style.flexDirection = 'column';
   mapContainer.style.alignItems = 'flex-start';
   mapContainer.style.gap = '12px';
+  mapContainer.style.width = '100%';
+  mapContainer.style.maxWidth = '100%';
 
   const sideStack = document.createElement('div');
   sideStack.className = `${idPrefix}-control-stack map-control-stack`;
@@ -588,6 +591,7 @@ export function createMapView(container, {
       mapContainer.style.flexDirection = 'row';
       mapContainer.style.flexWrap = 'nowrap';
       mapContainer.style.gap = '16px';
+      mapContainer.style.justifyContent = 'flex-start';
       if (!sideStack.parentElement) {
         mapContainer.appendChild(sideStack);
       }
@@ -605,6 +609,7 @@ export function createMapView(container, {
       mapContainer.style.flexDirection = 'column';
       mapContainer.style.flexWrap = 'nowrap';
       mapContainer.style.gap = '12px';
+      mapContainer.style.justifyContent = 'flex-start';
       if (sideStack.parentElement) {
         sideStack.parentElement.removeChild(sideStack);
       }
@@ -621,6 +626,18 @@ export function createMapView(container, {
     }
 
     requestFrame(updateTileSizing);
+    requestFrame(syncLayoutMetrics);
+  }
+
+  function syncLayoutMetrics() {
+    if (typeof document === 'undefined') return;
+    if (!layoutRoot?.isConnected) return;
+    const rect = typeof layoutRoot.getBoundingClientRect === 'function'
+      ? layoutRoot.getBoundingClientRect()
+      : null;
+    const width = rect?.width ? Math.round(rect.width) : 0;
+    if (!width) return;
+    document.documentElement.style.setProperty('--map-layout-width', `${width}px`);
   }
 
   function updateLegend(counts = {}) {
@@ -774,6 +791,7 @@ export function createMapView(container, {
 
     requestFrame(() => {
       updateTileSizing();
+      syncLayoutMetrics();
     });
   }
 
@@ -1044,6 +1062,9 @@ export function createMapView(container, {
       }
       if (layoutRoot.parentElement) {
         layoutRoot.parentElement.removeChild(layoutRoot);
+      }
+      if (typeof document !== 'undefined') {
+        document.documentElement.style.removeProperty('--map-layout-width');
       }
     },
     elements: {


### PR DESCRIPTION
## Summary
- anchor the map canvas to eliminate clipped tiles and expose the rendered width for layout consumers
- resize the HUD container and restyle the time banner chips so the icons sit directly on the bar
- drive the HUD width from the map layout via a CSS variable and clean it up when the view is destroyed

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e0029e21508325a2e6b171aaeaa510