### PR TITLE
Refine HUD menus and ensure full game map rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
       flex: 0 0 auto;
       align-items: center;
       justify-content: flex-end;
+      gap: 12px;
     }
     #time-banner .time-chip {
       display: inline-flex;
@@ -85,19 +86,17 @@
     #time-banner .time-chip span:last-child {
       font-weight: 500;
     }
-    .floating-action-bar {
+    .menu-action-group {
       display: inline-flex;
       align-items: center;
-      gap: 16px;
-      background: var(--bg-color);
-      border: 1px solid var(--map-border);
-      border-radius: 999px;
-      padding: 6px 18px;
-      min-height: 48px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-      position: relative;
+      gap: 12px;
     }
-    .floating-action-bar > button {
+    .menu-action {
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+    .menu-action > .menu-trigger {
       border: none;
       background: none;
       color: inherit;
@@ -107,41 +106,40 @@
       font-size: 24px;
       line-height: 1;
       cursor: pointer;
-      padding: 0;
-      height: 100%;
-      min-width: 40px;
-      transition: color 0.2s ease, transform 0.1s ease;
+      padding: 6px;
+      border-radius: 8px;
+      transition: background 0.2s ease, transform 0.1s ease;
     }
-    .floating-action-bar > button:hover {
+    .menu-action > .menu-trigger:hover {
       transform: translateY(-1px);
-      color: rgba(0, 0, 0, 0.7);
+      background: rgba(0, 0, 0, 0.08);
     }
-    body.dark .floating-action-bar > button:hover {
-      color: rgba(255, 255, 255, 0.85);
+    body.dark .menu-action > .menu-trigger:hover {
+      background: rgba(255, 255, 255, 0.12);
     }
-    .floating-action-bar > button:focus-visible {
+    .menu-action > .menu-trigger:focus-visible {
       outline: 2px solid #4a90e2;
       outline-offset: 2px;
     }
-    .floating-panel {
+    .menu-panel {
       position: absolute;
-      top: calc(100% + 6px);
+      top: calc(100% + 8px);
       right: 0;
       background: var(--menu-bg);
       border: 1px solid var(--map-border);
       border-radius: 12px;
-      padding: 8px;
+      padding: 10px;
       box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
-      min-width: 180px;
+      min-width: 200px;
       display: none;
       flex-direction: column;
-      gap: 6px;
+      gap: 8px;
       z-index: 1200;
     }
-    .floating-panel.open {
+    .menu-panel.open {
       display: flex;
     }
-    .floating-panel button {
+    .menu-panel button {
       border-radius: 8px;
       border: 1px solid transparent;
       background: transparent;
@@ -154,28 +152,28 @@
       gap: 8px;
       color: inherit;
     }
-    .floating-panel button:hover {
+    .menu-panel button:hover {
       background: rgba(0, 0, 0, 0.08);
     }
-    body.dark .floating-panel button:hover {
+    body.dark .menu-panel button:hover {
       background: rgba(255, 255, 255, 0.12);
     }
-    .floating-panel button:focus-visible {
+    .menu-panel button:focus-visible {
       outline: 2px solid #4a90e2;
       outline-offset: 2px;
     }
-    .floating-panel .panel-icon {
+    .menu-panel .panel-icon {
       width: 1.5em;
       text-align: center;
     }
-    .floating-panel .panel-label {
+    .menu-panel .panel-label {
       flex: 1 1 auto;
     }
-    .floating-panel .icon-row {
+    .menu-panel .icon-row {
       display: flex;
       gap: 6px;
     }
-    .floating-panel .icon-row button {
+    .menu-panel .icon-row button {
       flex: 1 1 auto;
       padding: 6px 0;
       justify-content: center;
@@ -183,6 +181,34 @@
       font-size: 1.1rem;
       display: inline-flex;
       align-items: center;
+    }
+    .menu-panel .theme-toggle-row {
+      display: flex;
+      gap: 6px;
+    }
+    .menu-panel .theme-toggle-button {
+      flex: 1 1 0;
+      font-size: 1.4rem;
+      padding: 8px 0;
+      border-radius: 10px;
+      border: 1px solid var(--map-border);
+      background: transparent;
+      transition: background 0.2s ease, border-color 0.2s ease, transform 0.1s ease;
+    }
+    .menu-panel .theme-toggle-button:hover {
+      transform: translateY(-1px);
+    }
+    .menu-panel .theme-toggle-button.active {
+      background: rgba(0, 0, 0, 0.08);
+      border-color: rgba(0, 0, 0, 0.2);
+    }
+    body.dark .menu-panel .theme-toggle-button.active {
+      background: rgba(255, 255, 255, 0.12);
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+    .menu-panel .zoom-display-button {
+      font-weight: 600;
+      letter-spacing: 0.04em;
     }
     #game {
       display: grid;

--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -1339,6 +1339,8 @@ export function initGameUI() {
       minWidth: '0'
     });
 
+    container.appendChild(mapSection);
+
     mapView = createMapView(mapSection, {
       legendLabels: LEGEND_LABELS,
       showControls: true,
@@ -1369,7 +1371,6 @@ export function initGameUI() {
       season: loc.map?.season
     });
 
-    container.appendChild(mapSection);
     lastSeason = store.time.season;
     renderTextMap();
   }


### PR DESCRIPTION
## Summary
- Replace the floating action bar with inline controls in the time banner and restyle the dropdown panels
- Add explicit light/dark theme buttons and a zoom reset indicator to the settings menu
- Append the game map section before initializing the map view so the board renders at full size after starting the game

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e03153807c8325bfec1a38f8a84101