### PR TITLE
Add spawn selection flow and player navigation UI

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -50,6 +50,15 @@ function startGame(settings = {}) {
   } else if (store.locations.size === 0) {
     generateLocation('loc1', 'temperate-deciduous', store.time.season, settings.seed);
   }
+
+  const spawn = settings.spawn || {};
+  const spawnX = Number.isFinite(spawn.x) ? Math.trunc(spawn.x) : 0;
+  const spawnY = Number.isFinite(spawn.y) ? Math.trunc(spawn.y) : 0;
+  store.player = {
+    locationId: 'loc1',
+    x: spawnX,
+    y: spawnY
+  };
   unlockTechnology({ id: 'basic-tools', name: 'Basic Tools' });
   refreshBuildingUnlocks();
   store.difficulty = diff;

--- a/src/state.js
+++ b/src/state.js
@@ -5,6 +5,7 @@ class DataStore {
     this.inventory = new Map();
     this.locations = new Map();
     this.technologies = new Map();
+    this.player = { locationId: null, x: 0, y: 0 };
     this.time = { day: 1, month: 1, year: 410, hour: 6, season: 'Thawbound', weather: 'Clear' };
     this.difficulty = 'normal';
     this.jobs = {};
@@ -51,6 +52,7 @@ class DataStore {
       inventory: [...this.inventory.entries()],
       locations: [...this.locations.entries()],
       technologies: [...this.technologies.entries()],
+      player: { ...this.player },
       time: this.time,
       difficulty: this.difficulty,
       jobs: this.jobs,
@@ -70,6 +72,12 @@ class DataStore {
     this.inventory = new Map(data.inventory || []);
     this.locations = new Map(data.locations || []);
     this.technologies = new Map(data.technologies || []);
+    const savedPlayer = data.player || {};
+    this.player = {
+      locationId: savedPlayer.locationId ?? null,
+      x: Number.isFinite(savedPlayer.x) ? Math.trunc(savedPlayer.x) : 0,
+      y: Number.isFinite(savedPlayer.y) ? Math.trunc(savedPlayer.y) : 0
+    };
     const savedTime = data.time || {};
     this.time = {
       day: 1,

--- a/src/ui.js
+++ b/src/ui.js
@@ -64,6 +64,10 @@ export function initSetupUI(onStart) {
 
   let mapData = null;
   let mapSeed = Date.now().toString();
+  let spawnCoords = null;
+  let spawnPrompt = null;
+  let pendingSpawn = null;
+  const spawnMarkerId = 'setup-spawn-marker';
 
   const mapSection = document.createElement('section');
   mapSection.style.marginTop = '12px';
@@ -71,6 +75,10 @@ export function initSetupUI(onStart) {
   const mapIntro = document.createElement('p');
   mapIntro.textContent = 'Preview of the surrounding area rendered with emoji terrain symbols. Each icon represents one patch of terrain. Use the navigation and zoom controls to examine different parts of the map.';
   mapSection.appendChild(mapIntro);
+
+  const spawnInfo = document.createElement('p');
+  spawnInfo.style.margin = '8px 0 0';
+  spawnInfo.style.fontStyle = 'italic';
 
   const seedRow = document.createElement('div');
   seedRow.style.display = 'flex';
@@ -106,6 +114,200 @@ export function initSetupUI(onStart) {
     ore: 'Ore Deposits'
   };
 
+  function hideSpawnPrompt() {
+    if (spawnPrompt) {
+      spawnPrompt.style.display = 'none';
+      spawnPrompt.setAttribute('aria-hidden', 'true');
+    }
+    pendingSpawn = null;
+  }
+
+  function ensureSpawnPrompt() {
+    const wrapper = mapView?.elements?.wrapper;
+    if (!wrapper) return null;
+    if (!spawnPrompt) {
+      spawnPrompt = document.createElement('div');
+      spawnPrompt.className = 'spawn-confirm';
+      spawnPrompt.setAttribute('role', 'dialog');
+      spawnPrompt.setAttribute('aria-modal', 'false');
+      spawnPrompt.setAttribute('aria-hidden', 'true');
+      Object.assign(spawnPrompt.style, {
+        position: 'absolute',
+        display: 'none',
+        flexDirection: 'column',
+        gap: '8px',
+        background: 'var(--bg-color, #fff)',
+        color: 'inherit',
+        border: '1px solid var(--map-border, #ccc)',
+        borderRadius: '10px',
+        padding: '12px 16px',
+        boxShadow: '0 8px 16px rgba(0, 0, 0, 0.2)',
+        zIndex: '10',
+        minWidth: '140px'
+      });
+      const question = document.createElement('p');
+      question.dataset.role = 'spawn-question';
+      question.style.margin = '0';
+      question.style.fontWeight = '600';
+      question.textContent = 'Spawn here?';
+      spawnPrompt.appendChild(question);
+
+      const buttonRow = document.createElement('div');
+      buttonRow.style.display = 'flex';
+      buttonRow.style.gap = '8px';
+      buttonRow.style.justifyContent = 'flex-end';
+
+      const yesBtn = document.createElement('button');
+      yesBtn.type = 'button';
+      yesBtn.textContent = 'Yes';
+      yesBtn.dataset.role = 'spawn-yes';
+      const noBtn = document.createElement('button');
+      noBtn.type = 'button';
+      noBtn.textContent = 'No';
+      noBtn.dataset.role = 'spawn-no';
+
+      buttonRow.appendChild(noBtn);
+      buttonRow.appendChild(yesBtn);
+      spawnPrompt.appendChild(buttonRow);
+
+      yesBtn.addEventListener('click', () => {
+        if (pendingSpawn) {
+          setSpawnCoords({ x: pendingSpawn.x, y: pendingSpawn.y });
+        }
+        hideSpawnPrompt();
+      });
+
+      noBtn.addEventListener('click', () => {
+        hideSpawnPrompt();
+      });
+    }
+
+    if (spawnPrompt.parentElement !== wrapper) {
+      spawnPrompt.parentElement?.removeChild(spawnPrompt);
+      wrapper.appendChild(spawnPrompt);
+    }
+
+    return spawnPrompt;
+  }
+
+  function showSpawnPrompt(detail) {
+    const prompt = ensureSpawnPrompt();
+    if (!prompt) return;
+    pendingSpawn = detail;
+    const question = prompt.querySelector('[data-role="spawn-question"]');
+    if (question) {
+      question.textContent = `Spawn here at (${detail.x}, ${detail.y})?`;
+    }
+
+    const wrapper = mapView?.elements?.wrapper;
+    if (wrapper && detail?.element?.getBoundingClientRect) {
+      const wrapperRect = wrapper.getBoundingClientRect();
+      const tileRect = detail.element.getBoundingClientRect();
+      const left = tileRect.left - wrapperRect.left + tileRect.width / 2;
+      const top = tileRect.top - wrapperRect.top + tileRect.height / 2;
+      prompt.style.left = `${left}px`;
+      prompt.style.top = `${top}px`;
+    } else {
+      prompt.style.left = '50%';
+      prompt.style.top = '50%';
+    }
+
+    prompt.style.transform = 'translate(-50%, -120%)';
+    prompt.style.display = 'flex';
+    prompt.setAttribute('aria-hidden', 'false');
+
+    const yesBtn = prompt.querySelector('[data-role="spawn-yes"]');
+    if (yesBtn) {
+      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(() => yesBtn.focus());
+      } else {
+        setTimeout(() => yesBtn.focus(), 0);
+      }
+    }
+  }
+
+  function computeDefaultSpawn(map) {
+    if (!map) return null;
+    const source = map.viewport || map;
+    const width = Math.max(1, Math.trunc(source?.width ?? DEFAULT_MAP_WIDTH));
+    const height = Math.max(1, Math.trunc(source?.height ?? DEFAULT_MAP_HEIGHT));
+    const xStart = Number.isFinite(source?.xStart)
+      ? Math.trunc(source.xStart)
+      : Number.isFinite(map?.xStart)
+        ? Math.trunc(map.xStart)
+        : 0;
+    const yStart = Number.isFinite(source?.yStart)
+      ? Math.trunc(source.yStart)
+      : Number.isFinite(map?.yStart)
+        ? Math.trunc(map.yStart)
+        : 0;
+    return {
+      x: xStart + Math.floor(width / 2),
+      y: yStart + Math.floor(height / 2)
+    };
+  }
+
+  function setSpawnCoords(coords = {}, options = {}) {
+    if (!coords) return;
+    const x = Number.isFinite(coords.x) ? Math.trunc(coords.x) : null;
+    const y = Number.isFinite(coords.y) ? Math.trunc(coords.y) : null;
+    if (x === null || y === null) return;
+    spawnCoords = { x, y };
+    if (!options.silent) {
+      hideSpawnPrompt();
+    }
+    updateSpawnMarker();
+    updateSpawnInfo();
+  }
+
+  function getTerrainAt(map, coords = {}) {
+    if (!map?.types?.length) return null;
+    const xStart = Number.isFinite(map.xStart) ? Math.trunc(map.xStart) : 0;
+    const yStart = Number.isFinite(map.yStart) ? Math.trunc(map.yStart) : 0;
+    const col = Math.trunc(coords.x) - xStart;
+    const row = Math.trunc(coords.y) - yStart;
+    if (row < 0 || col < 0) return null;
+    const rowData = map.types[row];
+    if (!rowData || col >= rowData.length) return null;
+    return rowData[col];
+  }
+
+  function describeTerrain(type) {
+    if (!type) return '';
+    return LEGEND_LABELS[type] || type;
+  }
+
+  function updateSpawnInfo() {
+    if (!spawnInfo) return;
+    if (!spawnCoords) {
+      spawnInfo.textContent = 'Click the map to choose your starting position.';
+      return;
+    }
+    const terrain = describeTerrain(getTerrainAt(mapData, spawnCoords));
+    const coordsText = `(${spawnCoords.x}, ${spawnCoords.y})`;
+    spawnInfo.textContent = terrain
+      ? `Chosen spawn point ${coordsText} – ${terrain}.`
+      : `Chosen spawn point ${coordsText}.`;
+  }
+
+  function updateSpawnMarker() {
+    if (!mapView || typeof mapView.setMarkers !== 'function') return;
+    const markers = spawnCoords
+      ? [
+          {
+            id: spawnMarkerId,
+            x: spawnCoords.x,
+            y: spawnCoords.y,
+            icon: '🧍',
+            className: 'map-marker--spawn',
+            label: 'Chosen spawn location',
+            emphasis: true
+          }
+        ]
+      : [];
+    mapView.setMarkers(markers);
+  }
+
   const mapView = createMapView(mapSection, {
     legendLabels: LEGEND_LABELS,
     showControls: true,
@@ -129,8 +331,16 @@ export function initSetupUI(onStart) {
     },
     onMapUpdate: updated => {
       mapData = { ...updated };
+      updateSpawnMarker();
+      updateSpawnInfo();
+    },
+    onTileClick: detail => {
+      showSpawnPrompt(detail);
     }
   });
+
+  mapSection.appendChild(spawnInfo);
+  updateSpawnInfo();
 
   form.appendChild(mapSection);
 
@@ -163,11 +373,14 @@ export function initSetupUI(onStart) {
 
   function renderMapPreview() {
     if (!mapData) return;
+    hideSpawnPrompt();
     mapView.setMap(mapData, {
       biomeId: biomeSelect.select.value,
       seed: mapData?.seed ?? mapSeed,
       season: mapData?.season ?? seasonSelect.select.value
     });
+    updateSpawnMarker();
+    updateSpawnInfo();
   }
 
   function generatePreview() {
@@ -183,6 +396,14 @@ export function initSetupUI(onStart) {
       height,
       seasonSelect.select.value
     );
+    const defaultSpawn = computeDefaultSpawn(mapData);
+    if (defaultSpawn) {
+      setSpawnCoords(defaultSpawn, { silent: true });
+    } else {
+      spawnCoords = null;
+      updateSpawnMarker();
+      updateSpawnInfo();
+    }
     renderMapPreview();
   }
 
@@ -219,7 +440,8 @@ export function initSetupUI(onStart) {
       biome: biomeSelect.select.value,
       season: seasonSelect.select.value,
       difficulty: diffSelect.select.value,
-      seed: mapSeed
+      seed: mapSeed,
+      spawn: spawnCoords ? { ...spawnCoords } : null
     });
   });
 


### PR DESCRIPTION
### Summary
* Added persistent player state in `src/state.js` and populate it during game start in `src/main.js`. 
* Setup UI (`src/ui.js`) now supports selecting a spawn tile with a confirmation prompt and highlights it on the preview map. 
* Enhanced `src/mapView.js` with marker overlays, tile click callbacks, and a “player” navigation mode so nav buttons drive character movement. 
* Game UI (`src/gameUI.js`) gains an explorer panel showing position, contextual actions, and uses the new nav mode/marker support to keep the player avatar on the map.
* Tweaked the explorer marker styling so the character icon renders at the same scale as other map icons.

### Outstanding TODOs / Follow-ups
* ❗ None of the new explorer actions actually execute game logic—`handlePlayerAction` in `src/gameUI.js` (lines ~398-403) just logs an event. Decide what each action should trigger.
* 🚫 There are no automated tests; consider adding coverage for map marker positioning and spawn selection flows.

### Testing Gaps / Risks
* Manual smoke test only (`npm test` prints “No tests specified”). No automated coverage of the new map interactions, explorer panel logic, or spawn prompt behavior.

### Open Issues / Gotchas
* The explorer panel assumes a single active location (`getActiveLocation()` returns the first location). If multiple locations are introduced later, this will need adjustment.
* The contextual action list bases availability purely on inventory items and terrain; expand it when job/skill systems exist.
* Make sure to run `npm test` (or add real tests) before shipping, since current script does nothing.

------
https://chatgpt.com/codex/tasks/task_e_68e0335e04a4832595a6f77603bf1fc8