### PR TITLE
Add terrain-aware travel, inventory popup, and proficiency tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,74 @@ duplicate or inconsistent data. Modules currently include:
 - **buildings** – available building types, constructed buildings and buildable
   options tied to unlocked technology.
 - **people** – population details and aggregate statistics.
-- **inventory** – resources with quantity and demand tracking.
+- **inventory** – resources with quantity, forecast supply, and demand tracking.
 - **location** – geographical generation based on biome.
-- **map** – generates 100×100 pixel color maps scaled to 100 m per tile.
+- **map** – generates 100×100 pixel color maps scaled to 100 m per tile (`GRID_DISTANCE_METERS`).
+- **movement** – converts tile distance and terrain into travel time.
+- **proficiencies** – character skills with diminishing returns and task metadata support.
 - **technology** – unlocked technologies which gate other features.
 - **time** – day and season progression.
 
 The application is a static site and can be served locally via any HTTP server
 that supports ES modules. The default entry point is `index.html` which loads
 `src/main.js`.
+
+## Gameplay systems
+
+### Travel distance and time
+
+Each map tile represents `GRID_DISTANCE_METERS` metres (currently 100 m). Movement between
+tiles factors in terrain and obstacles via `calculateTravelTime` in `src/movement.js`:
+
+- Open ground assumes a base pace of ~4.2 km/h.
+- Forest and rocky (`ore`) tiles slow movement with higher multipliers.
+- Water tiles require swimming skill; insufficient proficiency blocks movement and higher
+  skill reduces the water penalty.
+
+Diagonal moves automatically scale travel distance using the tile hypotenuse. Whenever a
+move succeeds, the game advances time by the computed duration and logs the distance,
+duration, and any additional difficulty messages.
+
+### Inventory forecasting
+
+The inventory view is now accessed from the floating menu (`🎒`). The popup lists:
+
+- **Item** – resource name with icon when available.
+- **#** – on-hand quantity.
+- **Supply (+)** – projected production from active/pending orders.
+- **Demand (-)** – projected consumption.
+
+`updateInventoryFlows` in `src/gameUI.js` keeps inventory records synchronised by calling
+`setItemFlow` for every known resource. When adding new orders, ensure the associated
+`metadata` describes the resource effects so that forecasting stays accurate.
+
+### Proficiency system
+
+`src/proficiencies.js` maintains settlement skills (hunting, foraging, gathering,
+swimming, tree felling, crafting, construction, combat). Each proficiency stores a level
+between 1 and 100 and gains are awarded via `rewardOrderProficiency` when orders complete.
+
+Task metadata should include:
+
+- `proficiencyId` – which skill receives experience.
+- `taskComplexity` – 1–100 rating describing the difficulty of the task.
+- `effortHours` – total worker-hours invested.
+- Optional `activity` and `taskId` strings for future analytics.
+
+Simple tasks grant diminishing returns: repeatedly finishing low-complexity work (for
+example cutting saplings) yields very small gains once a character outgrows the challenge.
+To progress, queue harder work (such as felling massive trees or complex constructions).
+
+Existing orders populate these fields automatically:
+
+- Manual orders from the Jobs board use `createOrderMetadata` to infer proficiency and
+  complexity from the type, worker count, hours, and optional notes (keywords like
+  “forage” or “sapling” tailor the skill).
+- Construction orders derive complexity from total labour and required resources inside
+  `beginConstruction`.
+
+Future features should follow the same pattern: define a `metadata` object when calling
+`queueOrder` so that proficiencies and inventory projections remain accurate.
 
 ## Development
 

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -262,6 +262,11 @@ export function beginConstruction(typeId, { workers, locationId } = {}) {
     perWorkerHourResources[name] = amount / totalWorkerHours;
   });
   const progressPerWorkerHour = totalLabor / totalWorkerHours;
+  const totalResourceUnits = Object.values(totalResources).reduce((sum, amount) => sum + amount, 0);
+  const baseComplexity = Math.min(
+    100,
+    28 + Math.log10(totalLabor + 1) * 18 + Math.log10(totalResourceUnits + 1) * 6
+  );
   return {
     project: { ...project },
     order: {
@@ -275,7 +280,12 @@ export function beginConstruction(typeId, { workers, locationId } = {}) {
         typeName: type.name,
         totalLaborHours: totalLabor,
         perWorkerHourResources,
-        progressPerWorkerHour
+        progressPerWorkerHour,
+        baseComplexity,
+        taskComplexity: baseComplexity,
+        effortHours: totalLabor,
+        proficiencyId: 'construction',
+        taskId: `construction:${typeId}`
       }
     }
   };

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import {
   showJobs,
   closeJobs,
   showConstructionDashboard,
+  showInventoryPopup,
   showProfilePopup,
   showLogPopup
 } from './gameUI.js';
@@ -83,7 +84,7 @@ function init() {
   initTopMenu(showJobs, closeJobs, () => {
     clearSave();
     window.location.reload();
-  }, showConstructionDashboard, showProfilePopup, showLogPopup);
+  }, showConstructionDashboard, showInventoryPopup, showProfilePopup, showLogPopup);
   initBottomMenu();
   if (!loadGame()) {
     initSetupUI(startGame);

--- a/src/map.js
+++ b/src/map.js
@@ -1,6 +1,8 @@
 import { getBiome } from './biomes.js';
 import store from './state.js';
 
+export const GRID_DISTANCE_METERS = 100;
+
 export const DEFAULT_MAP_SIZE = 64;
 export const DEFAULT_MAP_WIDTH = DEFAULT_MAP_SIZE;
 export const DEFAULT_MAP_HEIGHT = DEFAULT_MAP_SIZE;

--- a/src/menu.js
+++ b/src/menu.js
@@ -238,7 +238,7 @@ function buildSettingsPanel() {
   updateZoomDisplay();
 }
 
-function buildMenuPanel(onMenu, onBack, onReset, onConstruction, onProfile, onLog) {
+function buildMenuPanel(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog) {
   if (!menuPanel) return;
   menuPanel.innerHTML = '';
 
@@ -275,6 +275,15 @@ function buildMenuPanel(onMenu, onBack, onReset, onConstruction, onProfile, onLo
     constructionEntry.button.id = 'construction-btn';
     menuPanel.appendChild(constructionEntry.button);
     constructionMenuButton = constructionEntry.button;
+  }
+
+  if (typeof onInventory === 'function') {
+    const inventoryEntry = createPanelButton('🎒', 'Inventory', () => {
+      closePanels();
+      onInventory();
+    });
+    inventoryEntry.button.id = 'inventory-btn';
+    menuPanel.appendChild(inventoryEntry.button);
   }
 
   if (typeof onProfile === 'function') {
@@ -325,13 +334,13 @@ export function showBackButton(show) {
   }
 }
 
-export function initTopMenu(onMenu, onBack, onReset, onConstruction, onProfile, onLog) {
+export function initTopMenu(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog) {
   const bar = document.getElementById('top-menu');
   if (!bar) return;
   applyTheme();
   ensureActionBar();
   buildSettingsPanel();
-  buildMenuPanel(onMenu, onBack, onReset, onConstruction, onProfile, onLog);
+  buildMenuPanel(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog);
   bar.innerHTML = '';
   bar.style.display = 'none';
   applyZoom();

--- a/src/movement.js
+++ b/src/movement.js
@@ -1,0 +1,72 @@
+import { GRID_DISTANCE_METERS } from './map.js';
+
+const BASE_WALK_SPEED_METERS_PER_HOUR = 4200; // ~4.2 km/h average travel speed
+
+const TERRAIN_TIME_MULTIPLIER = {
+  open: 1,
+  forest: 1.7,
+  ore: 1.3,
+  water: 4,
+  default: 1.25
+};
+
+function terrainMultiplier(type) {
+  if (!type) return TERRAIN_TIME_MULTIPLIER.default;
+  return TERRAIN_TIME_MULTIPLIER[type] ?? TERRAIN_TIME_MULTIPLIER.default;
+}
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+export function calculateTravelTime({
+  fromTerrain = 'open',
+  toTerrain = 'open',
+  distance = GRID_DISTANCE_METERS,
+  swimmingLevel = 1
+} = {}) {
+  const baseDistance = Math.max(1, Number.isFinite(distance) ? distance : GRID_DISTANCE_METERS);
+  const originMultiplier = terrainMultiplier(fromTerrain);
+  const destinationMultiplier = terrainMultiplier(toTerrain);
+  let combinedMultiplier = (originMultiplier + destinationMultiplier) / 2;
+  let blocked = false;
+  let reason = '';
+
+  if (toTerrain === 'water' || fromTerrain === 'water') {
+    const swimSkill = clamp(swimmingLevel, 1, 100);
+    if (swimSkill < 8) {
+      blocked = true;
+      reason = 'The current is too strong to cross without better swimming skill.';
+    } else {
+      const swimPenalty = clamp(3.5 - swimSkill / 25, 1.5, 3.5);
+      combinedMultiplier *= swimPenalty;
+      if (swimSkill < 25) {
+        reason = 'Crossing the water is slow and exhausting.';
+      }
+    }
+  }
+
+  const hours = (baseDistance / BASE_WALK_SPEED_METERS_PER_HOUR) * combinedMultiplier;
+  return {
+    hours,
+    blocked,
+    reason,
+    distance: baseDistance,
+    multiplier: combinedMultiplier
+  };
+}
+
+export function describeTerrainDifficulty(type) {
+  switch (type) {
+    case 'forest':
+      return 'Dense canopy and underbrush slow travel.';
+    case 'ore':
+      return 'Rocky outcrops require careful footing.';
+    case 'water':
+      return 'Requires swimming or a bridge to cross.';
+    case 'open':
+    default:
+      return 'Gentle terrain allows steady progress.';
+  }
+}

--- a/src/proficiencies.js
+++ b/src/proficiencies.js
@@ -1,0 +1,231 @@
+import store from './state.js';
+
+export const PROFICIENCY_DEFINITIONS = [
+  {
+    id: 'hunting',
+    name: 'Hunting',
+    description: 'Tracking, stalking, and harvesting wild game.',
+    baseRate: 1.1,
+    defaultComplexity: 45,
+    diminishing: 0.9,
+    startLevel: 5
+  },
+  {
+    id: 'foraging',
+    name: 'Foraging',
+    description: 'Identifying edible and medicinal plants in the wild.',
+    baseRate: 0.95,
+    defaultComplexity: 32,
+    diminishing: 0.75,
+    startLevel: 5
+  },
+  {
+    id: 'gathering',
+    name: 'Gathering',
+    description: 'Collecting loose resources such as branches, stone, and salvage.',
+    baseRate: 0.9,
+    defaultComplexity: 24,
+    diminishing: 0.7,
+    startLevel: 5
+  },
+  {
+    id: 'swimming',
+    name: 'Swimming',
+    description: 'Crossing rivers, lakes, and flooded ground without aid.',
+    baseRate: 0.8,
+    defaultComplexity: 38,
+    diminishing: 1.2,
+    startLevel: 1
+  },
+  {
+    id: 'woodcutting',
+    name: 'Tree Felling',
+    description: 'Cutting timber, pruning, and shaping wood.',
+    baseRate: 1,
+    defaultComplexity: 40,
+    diminishing: 0.95,
+    startLevel: 5
+  },
+  {
+    id: 'crafting',
+    name: 'Crafting',
+    description: 'Hand crafting tools, garments, and trade goods.',
+    baseRate: 0.92,
+    defaultComplexity: 36,
+    diminishing: 0.85,
+    startLevel: 5
+  },
+  {
+    id: 'construction',
+    name: 'Construction',
+    description: 'Coordinating and executing building projects.',
+    baseRate: 0.9,
+    defaultComplexity: 44,
+    diminishing: 1,
+    startLevel: 5
+  },
+  {
+    id: 'combat',
+    name: 'Combat Readiness',
+    description: 'Armed drills, patrol discipline, and tactical awareness.',
+    baseRate: 1.05,
+    defaultComplexity: 55,
+    diminishing: 1.1,
+    startLevel: 5
+  }
+];
+
+const DEFINITION_MAP = new Map(PROFICIENCY_DEFINITIONS.map(def => [def.id, def]));
+
+const ORDER_PROFICIENCY_MAP = {
+  hunting: 'hunting',
+  gathering: 'gathering',
+  crafting: 'crafting',
+  building: 'construction',
+  combat: 'combat'
+};
+
+const DEFAULT_ORDER_COMPLEXITY = {
+  hunting: 48,
+  gathering: 26,
+  crafting: 38,
+  building: 46,
+  combat: 60
+};
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+function ensureProficiencyState() {
+  if (!(store.proficiencies instanceof Map)) {
+    store.proficiencies = new Map();
+  }
+  PROFICIENCY_DEFINITIONS.forEach(def => {
+    if (!store.proficiencies.has(def.id)) {
+      store.proficiencies.set(def.id, {
+        id: def.id,
+        level: def.startLevel ?? 1,
+        lastComplexity: def.defaultComplexity,
+        lastUpdated: Date.now()
+      });
+    }
+  });
+  return store.proficiencies;
+}
+
+export function getProficiency(id) {
+  const map = ensureProficiencyState();
+  const def = DEFINITION_MAP.get(id);
+  const entry = map.get(id);
+  if (!def) {
+    return {
+      id,
+      name: id,
+      level: entry?.level ?? 1,
+      lastComplexity: entry?.lastComplexity ?? 0
+    };
+  }
+  return {
+    id: def.id,
+    name: def.name,
+    description: def.description,
+    level: entry?.level ?? def.startLevel ?? 1,
+    lastComplexity: entry?.lastComplexity ?? def.defaultComplexity
+  };
+}
+
+export function getProficiencyLevel(id) {
+  return getProficiency(id).level;
+}
+
+export function getProficiencies() {
+  ensureProficiencyState();
+  return PROFICIENCY_DEFINITIONS.map(def => getProficiency(def.id));
+}
+
+function effortFactor(hours = 0) {
+  const numeric = Number.isFinite(hours) ? Math.max(0, hours) : 0;
+  if (numeric <= 0) return 0;
+  return Math.log10(numeric + 1) + 1;
+}
+
+function resolveDefinition(id) {
+  const def = DEFINITION_MAP.get(id);
+  if (!def) return null;
+  ensureProficiencyState();
+  return def;
+}
+
+export function recordTaskCompletion({
+  proficiencyId,
+  complexity,
+  effortHours,
+  success = true
+} = {}) {
+  const def = resolveDefinition(proficiencyId);
+  if (!def) return null;
+  const map = ensureProficiencyState();
+  const state = map.get(proficiencyId) || {
+    id: proficiencyId,
+    level: def.startLevel ?? 1,
+    lastComplexity: def.defaultComplexity,
+    lastUpdated: Date.now()
+  };
+  const currentLevel = Number.isFinite(state.level) ? state.level : def.startLevel ?? 1;
+  const normalizedComplexity = clamp(
+    Number.isFinite(complexity) ? complexity : def.defaultComplexity,
+    1,
+    200
+  );
+  const effort = effortFactor(effortHours);
+  if (effort <= 0) {
+    return { id: def.id, name: def.name, level: currentLevel, gained: 0, previousLevel: currentLevel };
+  }
+  const diminishing = def.diminishing ?? 1;
+  const difficultyFactor = normalizedComplexity /
+    (normalizedComplexity + Math.max(0, currentLevel - 1) * diminishing);
+  const rate = def.baseRate ?? 1;
+  const successFactor = success ? 1 : 0.35;
+  const gained = rate * effort * difficultyFactor * successFactor;
+  const newLevel = clamp(currentLevel + gained, 1, 100);
+  map.set(proficiencyId, {
+    id: proficiencyId,
+    level: newLevel,
+    lastComplexity: normalizedComplexity,
+    lastUpdated: Date.now()
+  });
+  return {
+    id: def.id,
+    name: def.name,
+    level: newLevel,
+    gained: newLevel - currentLevel,
+    previousLevel: currentLevel
+  };
+}
+
+export function rewardOrderProficiency(order, options = {}) {
+  if (!order) return null;
+  const proficiencyId =
+    options.proficiencyId || order.metadata?.proficiencyId || ORDER_PROFICIENCY_MAP[order.type];
+  if (!proficiencyId) return null;
+  const def = resolveDefinition(proficiencyId);
+  if (!def) return null;
+  const complexity = options.complexity ?? order.metadata?.taskComplexity ?? order.metadata?.baseComplexity ??
+    DEFAULT_ORDER_COMPLEXITY[order.type] ?? def.defaultComplexity;
+  const workers = Number.isFinite(order.workers) ? Math.max(1, order.workers) : 1;
+  const duration = Number.isFinite(order.durationHours) ? Math.max(1, order.durationHours) : 1;
+  const effortHours = options.effortHours ?? order.metadata?.effortHours ?? workers * duration;
+  const success = options.success !== false;
+  return recordTaskCompletion({
+    proficiencyId,
+    complexity,
+    effortHours,
+    success
+  });
+}
+
+export function inferOrderProficiency(type) {
+  return ORDER_PROFICIENCY_MAP[type] || null;
+}

--- a/src/state.js
+++ b/src/state.js
@@ -5,6 +5,7 @@ class DataStore {
     this.inventory = new Map();
     this.locations = new Map();
     this.technologies = new Map();
+    this.proficiencies = new Map();
     this.player = { locationId: null, x: 0, y: 0 };
     this.time = { day: 1, month: 1, year: 410, hour: 6, season: 'Thawbound', weather: 'Clear' };
     this.difficulty = 'normal';
@@ -52,6 +53,7 @@ class DataStore {
       inventory: [...this.inventory.entries()],
       locations: [...this.locations.entries()],
       technologies: [...this.technologies.entries()],
+      proficiencies: [...this.proficiencies.entries()],
       player: { ...this.player },
       time: this.time,
       difficulty: this.difficulty,
@@ -72,6 +74,7 @@ class DataStore {
     this.inventory = new Map(data.inventory || []);
     this.locations = new Map(data.locations || []);
     this.technologies = new Map(data.technologies || []);
+    this.proficiencies = new Map(data.proficiencies || []);
     const savedPlayer = data.player || {};
     this.player = {
       locationId: savedPlayer.locationId ?? null,


### PR DESCRIPTION
## Summary
- calculate tile-to-tile travel time with terrain-aware movement penalties and log the results
- move inventory tracking into a floating menu popup with projected supply and demand flows
- introduce a proficiency system with diminishing returns, task metadata, and documentation for future extensions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e04f37e5bc83259beeb431114ad0f6