### PR TITLE
Add modal action menus and workforce planners

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,20 +21,20 @@
       --action-button-shadow-active: 0 6px 16px rgba(45, 108, 223, 0.35);
     }
     body.dark {
-      --bg-color: #222;
-      --text-color: #eee;
-      --menu-bg: #333;
-      --map-bg: #3a3a3a;
-      --map-border: #555;
-      --action-panel-bg: rgba(34, 34, 42, 0.96);
-      --action-option-bg: rgba(52, 52, 60, 0.92);
-      --action-button-bg: linear-gradient(135deg, rgba(60, 60, 78, 0.94), rgba(42, 42, 54, 0.9));
+      --bg-color: #0c1324;
+      --text-color: #f1f4ff;
+      --menu-bg: rgba(16, 24, 44, 0.94);
+      --map-bg: #101b33;
+      --map-border: rgba(82, 114, 204, 0.55);
+      --action-panel-bg: rgba(16, 27, 53, 0.95);
+      --action-option-bg: rgba(24, 38, 70, 0.9);
+      --action-button-bg: linear-gradient(135deg, rgba(26, 43, 86, 0.96), rgba(44, 74, 146, 0.92));
       --action-button-text: var(--text-color);
-      --action-button-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
-      --action-button-shadow-hover: 0 8px 18px rgba(0, 0, 0, 0.6);
-      --action-button-bg-active: linear-gradient(135deg, rgba(86, 135, 255, 0.92), rgba(53, 94, 201, 0.95));
-      --action-button-text-active: #f8f8ff;
-      --action-button-shadow-active: 0 8px 18px rgba(33, 66, 150, 0.6);
+      --action-button-shadow: 0 3px 12px rgba(6, 12, 32, 0.55);
+      --action-button-shadow-hover: 0 10px 24px rgba(8, 20, 48, 0.65);
+      --action-button-bg-active: linear-gradient(135deg, rgba(68, 119, 255, 0.95), rgba(33, 77, 180, 0.96));
+      --action-button-text-active: #f6f8ff;
+      --action-button-shadow-active: 0 12px 26px rgba(24, 54, 138, 0.7);
     }
     * {
       box-sizing: border-box;

--- a/src/craftPlanner.js
+++ b/src/craftPlanner.js
@@ -1,0 +1,121 @@
+import store from './state.js';
+import { saveGame } from './persistence.js';
+
+function ensureTargets() {
+  if (!(store.craftTargets instanceof Map)) {
+    if (Array.isArray(store.craftTargets)) {
+      store.craftTargets = new Map(store.craftTargets);
+    } else {
+      store.craftTargets = new Map();
+    }
+  }
+}
+
+function normalizeId(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function safeQuantity(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+  return Math.max(0, Math.trunc(numeric));
+}
+
+function sumCollection(source, targetId) {
+  if (!source || !targetId) return 0;
+  const normalizedTarget = normalizeId(targetId);
+  if (!normalizedTarget) return 0;
+  if (typeof source === 'string') {
+    return normalizeId(source) === normalizedTarget ? 1 : 0;
+  }
+  if (Array.isArray(source)) {
+    return source.reduce((total, entry) => total + sumCollection(entry, normalizedTarget), 0);
+  }
+  if (source instanceof Map) {
+    let total = 0;
+    source.forEach((value, key) => {
+      if (normalizeId(key) === normalizedTarget) {
+        total += safeQuantity(value) || 0;
+      } else {
+        total += sumCollection(value, normalizedTarget);
+      }
+    });
+    return total;
+  }
+  if (typeof source === 'object') {
+    const candidate = source.id ?? source.name ?? source.item ?? source.type ?? source.slug;
+    if (candidate && normalizeId(candidate) === normalizedTarget) {
+      const qty =
+        source.quantity ??
+        source.qty ??
+        source.count ??
+        source.amount ??
+        source.number ??
+        1;
+      const numeric = safeQuantity(qty);
+      return numeric > 0 ? numeric : 1;
+    }
+    return Object.keys(source).reduce((total, key) => {
+      const value = source[key];
+      if (normalizeId(key) === normalizedTarget && typeof value !== 'object') {
+        return total + safeQuantity(value);
+      }
+      return total + sumCollection(value, normalizedTarget);
+    }, 0);
+  }
+  return 0;
+}
+
+export function getCraftTarget(itemId) {
+  ensureTargets();
+  if (!itemId) return 0;
+  const key = String(itemId);
+  return store.craftTargets.get(key) || 0;
+}
+
+export function setCraftTarget(itemId, quantity) {
+  if (!itemId) return;
+  ensureTargets();
+  const key = String(itemId);
+  const desired = safeQuantity(quantity);
+  if (!desired) {
+    store.craftTargets.delete(key);
+  } else {
+    store.craftTargets.set(key, desired);
+  }
+  saveGame();
+}
+
+export function listCraftTargets() {
+  ensureTargets();
+  return Array.from(store.craftTargets.entries()).map(([id, target]) => ({ id, target }));
+}
+
+export function calculateReservedQuantity(itemId) {
+  if (!itemId) return 0;
+  const normalized = normalizeId(itemId);
+  if (!normalized) return 0;
+  let total = 0;
+  store.people.forEach(person => {
+    total += sumCollection(person?.equipment, normalized);
+    total += sumCollection(person?.equipped, normalized);
+    total += sumCollection(person?.heldItems, normalized);
+    total += sumCollection(person?.held, normalized);
+    total += sumCollection(person?.holding, normalized);
+  });
+  return total;
+}
+
+export function clearCraftTarget(itemId) {
+  if (!itemId) return;
+  ensureTargets();
+  store.craftTargets.delete(String(itemId));
+  saveGame();
+}
+
+export function resetCraftTargets() {
+  ensureTargets();
+  store.craftTargets.clear();
+  saveGame();
+}
+

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -2,16 +2,77 @@ import store from './state.js';
 import { stats as peopleStats } from './people.js';
 import { saveGame } from './persistence.js';
 
+const JOB_DEFINITIONS = [
+  {
+    id: 'gather',
+    label: 'Gatherers',
+    description: 'Collect forage, firewood, and loose materials from the surrounding area.'
+  },
+  {
+    id: 'hunt',
+    label: 'Hunters',
+    description: 'Track game to keep the settlement supplied with meat and hides.'
+  },
+  {
+    id: 'craft',
+    label: 'Crafters',
+    description: 'Maintain tools, weave cordage, and assemble needed goods.'
+  },
+  {
+    id: 'build',
+    label: 'Builders',
+    description: 'Raise new structures and shore up existing shelters.'
+  },
+  {
+    id: 'guard',
+    label: 'Guards',
+    description: 'Keep watch for danger and respond to hostile threats.'
+  }
+];
+
+function normalizeLegacyJobs() {
+  if (!store.jobs || typeof store.jobs !== 'object') {
+    store.jobs = {};
+  }
+  if (Object.prototype.hasOwnProperty.call(store.jobs, 'scavenge')) {
+    const carryOver = Math.max(0, Number(store.jobs.scavenge) || 0);
+    store.jobs.gather = Math.max(0, (store.jobs.gather || 0) + carryOver);
+    delete store.jobs.scavenge;
+  }
+}
+
 function ensureJobs() {
-  if (!store.jobs) store.jobs = {};
+  normalizeLegacyJobs();
+  JOB_DEFINITIONS.forEach(def => {
+    const current = Number(store.jobs[def.id]);
+    store.jobs[def.id] = Number.isFinite(current) && current > 0 ? Math.trunc(current) : 0;
+  });
+}
+
+export function listJobDefinitions() {
+  return JOB_DEFINITIONS.map(def => ({ ...def }));
+}
+
+export function getJobOverview() {
+  ensureJobs();
+  const adults = peopleStats().adults || 0;
+  const assignments = JOB_DEFINITIONS.map(def => ({
+    ...def,
+    assigned: store.jobs[def.id] || 0
+  }));
+  const assignedTotal = assignments.reduce((sum, job) => sum + job.assigned, 0);
+  const laborer = Math.max(0, adults - assignedTotal);
+  return { assignments, adults, assigned: assignedTotal, laborer };
 }
 
 export function getJobs() {
-  ensureJobs();
-  const adults = peopleStats().adults || 0;
-  const assigned = Object.values(store.jobs).reduce((a, b) => a + b, 0);
-  const laborer = Math.max(0, adults - assigned);
-  return { ...store.jobs, laborer };
+  const overview = getJobOverview();
+  const jobs = {};
+  overview.assignments.forEach(job => {
+    jobs[job.id] = job.assigned;
+  });
+  jobs.laborer = overview.laborer;
+  return jobs;
 }
 
 export function setJob(name, count) {
@@ -22,11 +83,12 @@ export function setJob(name, count) {
     .filter(([k]) => k !== name)
     .reduce((sum, [, v]) => sum + v, 0);
   const max = Math.max(0, adults - others);
-  store.jobs[name] = Math.max(0, Math.min(count, max));
+  const desired = Math.max(0, Math.trunc(Number.isFinite(count) ? count : 0));
+  store.jobs[name] = Math.max(0, Math.min(desired, max));
   saveGame();
 }
 
 export function totalAssigned() {
-  ensureJobs();
-  return Object.values(store.jobs).reduce((a, b) => a + b, 0);
+  const overview = getJobOverview();
+  return overview.assigned;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,8 @@ import {
   showConstructionDashboard,
   showInventoryPopup,
   showProfilePopup,
-  showLogPopup
+  showLogPopup,
+  showCraftPlannerPopup
 } from './gameUI.js';
 import { initTopMenu, initBottomMenu } from './menu.js';
 import { resetToDawn, getSeasonDetails, getSeasonForMonth, randomDarkAgeYear } from './time.js';
@@ -63,8 +64,9 @@ function startGame(settings = {}) {
   unlockTechnology({ id: 'basic-tools', name: 'Basic Tools' });
   refreshBuildingUnlocks();
   store.difficulty = diff;
-  // Initialize available jobs, starting with scavenging
-  store.jobs = { scavenge: 0 };
+  // Initialize available jobs
+  store.jobs = { gather: 0, hunt: 0, craft: 0, build: 0, guard: 0 };
+  store.craftTargets = new Map();
   store.buildQueue = 0;
   store.haulQueue = 0;
   resetOrders();
@@ -84,7 +86,7 @@ function init() {
   initTopMenu(showJobs, closeJobs, () => {
     clearSave();
     window.location.reload();
-  }, showConstructionDashboard, showInventoryPopup, showProfilePopup, showLogPopup);
+  }, showConstructionDashboard, showInventoryPopup, showProfilePopup, showLogPopup, showCraftPlannerPopup);
   initBottomMenu();
   if (!loadGame()) {
     initSetupUI(startGame);

--- a/src/menu.js
+++ b/src/menu.js
@@ -238,7 +238,7 @@ function buildSettingsPanel() {
   updateZoomDisplay();
 }
 
-function buildMenuPanel(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog) {
+function buildMenuPanel(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog, onCraftPlanner) {
   if (!menuPanel) return;
   menuPanel.innerHTML = '';
 
@@ -261,10 +261,18 @@ function buildMenuPanel(onMenu, onBack, onReset, onConstruction, onInventory, on
     const jobsEntry = createPanelButton('👷', 'Jobs', () => {
       closePanels();
       onMenu();
-      showBackButton(true);
     });
     jobsEntry.button.id = 'jobs-btn';
     menuPanel.appendChild(jobsEntry.button);
+  }
+
+  if (typeof onCraftPlanner === 'function') {
+    const craftPlannerEntry = createPanelButton('🧰', 'Craft Planner', () => {
+      closePanels();
+      onCraftPlanner();
+    });
+    craftPlannerEntry.button.id = 'craft-planner-btn';
+    menuPanel.appendChild(craftPlannerEntry.button);
   }
 
   if (typeof onConstruction === 'function') {
@@ -334,13 +342,13 @@ export function showBackButton(show) {
   }
 }
 
-export function initTopMenu(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog) {
+export function initTopMenu(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog, onCraftPlanner) {
   const bar = document.getElementById('top-menu');
   if (!bar) return;
   applyTheme();
   ensureActionBar();
   buildSettingsPanel();
-  buildMenuPanel(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog);
+  buildMenuPanel(onMenu, onBack, onReset, onConstruction, onInventory, onProfile, onLog, onCraftPlanner);
   bar.innerHTML = '';
   bar.style.display = 'none';
   applyZoom();

--- a/src/state.js
+++ b/src/state.js
@@ -3,6 +3,7 @@ class DataStore {
     this.buildings = new Map();
     this.people = new Map();
     this.inventory = new Map();
+    this.craftTargets = new Map();
     this.locations = new Map();
     this.technologies = new Map();
     this.proficiencies = new Map();
@@ -52,6 +53,7 @@ class DataStore {
       buildings: [...this.buildings.entries()],
       people: [...this.people.entries()],
       inventory: [...this.inventory.entries()],
+      craftTargets: [...this.craftTargets.entries()],
       locations: [...this.locations.entries()],
       technologies: [...this.technologies.entries()],
       proficiencies: [...this.proficiencies.entries()],
@@ -74,6 +76,7 @@ class DataStore {
     this.buildings = new Map(data.buildings || []);
     this.people = new Map(data.people || []);
     this.inventory = new Map(data.inventory || []);
+    this.craftTargets = new Map(data.craftTargets || []);
     this.locations = new Map(data.locations || []);
     this.technologies = new Map(data.technologies || []);
     this.proficiencies = new Map(data.proficiencies || []);


### PR DESCRIPTION
## Summary
- align the dark theme palette with the refreshed action button styling
- swap the map action slide-out for centered modals and restyle navigation controls
- replace the jobs sheet with a popup dialog and add a craft planner with persistent targets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0771337188325ba40b33075dde747