### PR TITLE
Improve job assignments and crafting throughput

### DIFF
--- a/src/buildings.js
+++ b/src/buildings.js
@@ -97,10 +97,14 @@ function featureMatches(features = [], tag = '') {
 function locationSupports(type) {
   const tags = type.requirements?.locationTags || [];
   if (!tags.length) return true;
+  const normalizedTags = tags.map(tag => String(tag || '').toLowerCase());
+  if (normalizedTags.some(tag => tag === 'open' || tag === 'any')) {
+    return true;
+  }
   const locations = allLocations();
   if (!locations.length) return false;
   const features = (locations[0]?.features || []).map(f => f.toLowerCase());
-  return tags.some(tag => featureMatches(features, tag));
+  return normalizedTags.some(tag => featureMatches(features, tag));
 }
 
 function hasResearch(id) {


### PR DESCRIPTION
## Summary
- streamline the jobs dialog to one-line rows with arrow controls and tooltip details
- compute crafting duration from crafter man-hours, enforcing workforce availability before consuming materials
- treat "open" terrain requirements as universal so basic structures like fire pits no longer block on terrain

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0836bc9948325bf9c710d6b4f7b83