### PR TITLE
Reposition event log above top menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       width: 100%;
       max-width: 1024px;
       margin: 0 auto;
-      padding: clamp(56px, 8vh, 96px) 16px clamp(72px, 12vh, 128px);
+      padding: 7px 16px clamp(72px, 12vh, 128px);
       display: flex;
       flex-direction: column;
       gap: 24px;
@@ -253,7 +253,7 @@
     }
     @media (max-width: 768px) {
       #content {
-        padding: clamp(56px, 12vh, 88px) 12px clamp(72px, 16vh, 140px);
+        padding: 7px 12px clamp(72px, 16vh, 140px);
         gap: 16px;
       }
       #game {

--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -696,15 +696,20 @@ function ensureEventLogPanel() {
     eventLogPanel.appendChild(eventLogSummaryList);
   }
 
-  if (!eventLogPanel.parentElement) {
-    const content = document.getElementById('content');
-    if (content) {
-      const gameContainer = document.getElementById('game');
-      if (gameContainer && content.contains(gameContainer)) {
-        content.insertBefore(eventLogPanel, gameContainer);
-      } else {
-        content.appendChild(eventLogPanel);
-      }
+  const content = document.getElementById('content');
+  if (content) {
+    const gameContainer = document.getElementById('game');
+    let anchor = null;
+    if (timeBanner && timeBanner.parentElement === content) {
+      anchor = timeBanner;
+    } else if (gameContainer && content.contains(gameContainer)) {
+      anchor = gameContainer;
+    }
+
+    if (anchor) {
+      content.insertBefore(eventLogPanel, anchor);
+    } else if (eventLogPanel.parentElement !== content || content.firstChild !== eventLogPanel) {
+      content.insertBefore(eventLogPanel, content.firstChild);
     }
   }
 


### PR DESCRIPTION
## Summary
- move the in-page event log above the top menu/time banner for immediate visibility
- reduce the page content's top padding to 7px to tighten space above the menu on all viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0a942cee483259e175570789950bc