### PR TITLE
Add site capacity tracking and staged construction requirements

### DIFF
--- a/src/buildingCatalog.js
+++ b/src/buildingCatalog.js
@@ -9,7 +9,13 @@ export const buildingCatalog = [
     unlock: { always: true },
     requirements: {
       minBuilders: 1,
-      locationTags: ['forest', 'grove']
+      locationTags: ['forest', 'grove'],
+      site: {
+        category: 'forest',
+        dimensions: { width: 3.6, depth: 2.1 },
+        accessClearance: { front: 2.4, back: 0.6, left: 0.6, right: 0.6 }
+      },
+      craftedGoods: { cord: 8 }
     },
     effects: {
       occupancy: 2,
@@ -28,16 +34,17 @@ export const buildingCatalog = [
       },
       {
         id: 'main-supports',
-        name: 'Frame & Supports',
-        description: 'Cut saplings to form the main ridge pole and rear supports.',
+        name: 'Ridge Frame & Lashings',
+        description: 'Raise forked poles and lash the ridge beam that anchors the shelter.',
         laborHours: 6,
         minBuilders: 1,
+        isCore: true,
         resources: { firewood: 28, 'plant fibers': 12, cord: 4 }
       },
       {
         id: 'roof',
-        name: 'Roof Thatched Cover',
-        description: 'Lay overlapping boughs and brush to create a water-shedding roof.',
+        name: 'Weather Shed Cover',
+        description: 'Lay overlapping boughs down the leeward slope and extend a front overhang for access.',
         laborHours: 5,
         minBuilders: 1,
         resources: { firewood: 18, 'plant fibers': 16, cord: 4 }
@@ -74,7 +81,13 @@ export const buildingCatalog = [
     unlock: { always: true },
     requirements: {
       minBuilders: 1,
-      locationTags: ['meadow', 'open']
+      locationTags: ['forest', 'grove', 'meadow', 'open'],
+      site: {
+        categories: ['forest', 'cleared'],
+        dimensions: { width: 1.8, depth: 1.8 },
+        accessClearance: { front: 1.8, back: 1.8, left: 1.8, right: 1.8 }
+      },
+      craftedGoods: { 'crafted goods': 2 }
     },
     effects: {
       comfort: 1,
@@ -89,6 +102,7 @@ export const buildingCatalog = [
         description: 'Excavate a shallow basin and line it with gravel for drainage.',
         laborHours: 3,
         minBuilders: 1,
+        isCore: true,
         resources: { pebbles: 30 }
       },
       {
@@ -141,7 +155,13 @@ export const buildingCatalog = [
     },
     requirements: {
       minBuilders: 1,
-      locationTags: ['meadow', 'shore', 'open']
+      locationTags: ['meadow', 'shore', 'open'],
+      site: {
+        category: 'cleared',
+        dimensions: { width: 3, depth: 1.8 },
+        accessClearance: { front: 1.2, back: 1.2, left: 1, right: 1 }
+      },
+      craftedGoods: { cord: 9, 'crafted goods': 1 }
     },
     effects: {
       supply: { preservedFood: 1, hides: 0.5 },
@@ -155,6 +175,7 @@ export const buildingCatalog = [
         description: 'Set four sturdy posts to lift the rack clear of pests.',
         laborHours: 4,
         minBuilders: 1,
+        isCore: true,
         resources: { firewood: 22, 'plant fibers': 8, cord: 3 }
       },
       {
@@ -199,7 +220,13 @@ export const buildingCatalog = [
     },
     requirements: {
       minBuilders: 2,
-      locationTags: ['forest']
+      locationTags: ['forest'],
+      site: {
+        category: 'forest',
+        dimensions: { width: 2.4, depth: 2.4 },
+        accessClearance: { front: 1.8, back: 1.2, left: 1.5, right: 1.5 }
+      },
+      craftedGoods: { cord: 14, 'crafted goods': 2 }
     },
     effects: {
       supply: { food: 1.5, hides: 0.5 },
@@ -213,6 +240,7 @@ export const buildingCatalog = [
         description: 'Drive support poles deep and brace against sway.',
         laborHours: 6,
         minBuilders: 2,
+        isCore: true,
         resources: { firewood: 36, 'small stones': 12, 'plant fibers': 10, cord: 4 }
       },
       {
@@ -265,7 +293,13 @@ export const buildingCatalog = [
     },
     requirements: {
       minBuilders: 3,
-      locationTags: ['meadow', 'open']
+      locationTags: ['meadow', 'open'],
+      site: {
+        category: 'cleared',
+        dimensions: { width: 6, depth: 8 },
+        accessClearance: { front: 2.5, back: 2, left: 1.5, right: 1.5 }
+      },
+      craftedGoods: { cord: 16, 'crafted goods': 7 }
     },
     effects: {
       supply: { 'crafted goods': 2 },
@@ -279,6 +313,7 @@ export const buildingCatalog = [
         description: 'Lay compacted earth and stone to level the workspace.',
         laborHours: 6,
         minBuilders: 2,
+        isCore: true,
         resources: { 'small stones': 30, pebbles: 40 }
       },
       {
@@ -331,7 +366,13 @@ export const buildingCatalog = [
     },
     requirements: {
       minBuilders: 3,
-      locationTags: ['river', 'lake', 'shore', 'open']
+      locationTags: ['river', 'lake', 'shore', 'open'],
+      site: {
+        category: 'cleared',
+        dimensions: { width: 4.2, depth: 4.2 },
+        accessClearance: { front: 3, back: 1.5, left: 1.5, right: 1.5 }
+      },
+      craftedGoods: { cord: 15, 'crafted goods': 4 }
     },
     effects: {
       supply: { preservedFood: 4 },
@@ -345,6 +386,7 @@ export const buildingCatalog = [
         description: 'Create a sealed stone base to contain smoke.',
         laborHours: 8,
         minBuilders: 3,
+        isCore: true,
         resources: { 'small stones': 60, pebbles: 60 }
       },
       {
@@ -397,7 +439,13 @@ export const buildingCatalog = [
     },
     requirements: {
       minBuilders: 4,
-      locationTags: ['meadow', 'open']
+      locationTags: ['meadow', 'open'],
+      site: {
+        category: 'cleared',
+        dimensions: { width: 8, depth: 24 },
+        accessClearance: { front: 3, back: 3, left: 2.5, right: 2.5 }
+      },
+      craftedGoods: { cord: 66, 'crafted goods': 13 }
     },
     effects: {
       occupancy: 12,
@@ -413,6 +461,7 @@ export const buildingCatalog = [
         description: 'Set heavy sills on stone footings to lift the structure.',
         laborHours: 12,
         minBuilders: 4,
+        isCore: true,
         resources: { firewood: 200, 'small stones': 40, 'plant fibers': 40, cord: 12 }
       },
       {
@@ -482,7 +531,13 @@ export const buildingCatalog = [
     },
     requirements: {
       minBuilders: 3,
-      locationTags: ['cliff', 'ridge', 'hill', 'high']
+      locationTags: ['cliff', 'ridge', 'hill', 'high'],
+      site: {
+        category: 'cleared',
+        dimensions: { width: 4, depth: 4 },
+        accessClearance: { front: 3, back: 3, left: 3, right: 3 }
+      },
+      craftedGoods: { cord: 38, 'crafted goods': 8 }
     },
     effects: {
       survivability: 3,
@@ -496,6 +551,7 @@ export const buildingCatalog = [
         description: 'Dig deep footings and backfill with stone for stability.',
         laborHours: 10,
         minBuilders: 3,
+        isCore: true,
         resources: { 'small stones': 70, pebbles: 80, firewood: 60, 'plant fibers': 20, cord: 6 }
       },
       {

--- a/src/location.js
+++ b/src/location.js
@@ -1,7 +1,56 @@
 import store from './state.js';
 import { getBiome } from './biomes.js';
 import { generatePointsOfInterest } from './pointsOfInterest.js';
-import { computeCenteredStart, DEFAULT_MAP_HEIGHT, DEFAULT_MAP_WIDTH, generateColorMap } from './map.js';
+import {
+  computeCenteredStart,
+  DEFAULT_MAP_HEIGHT,
+  DEFAULT_MAP_WIDTH,
+  generateColorMap,
+  GRID_DISTANCE_METERS
+} from './map.js';
+
+const CLEAR_TERRAIN_TYPES = new Set(['open', 'ore', 'stone']);
+
+function normalizeNumber(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return 0;
+  return num;
+}
+
+function computeSiteCapacities(map) {
+  if (!map || !Array.isArray(map.types)) {
+    return { forest: 0, cleared: 0 };
+  }
+  const areaPerTile = normalizeNumber(GRID_DISTANCE_METERS) ** 2 || 0;
+  let forestTiles = 0;
+  let clearedTiles = 0;
+  map.types.forEach(row => {
+    row.forEach(type => {
+      if (type === 'forest') {
+        forestTiles += 1;
+      } else if (CLEAR_TERRAIN_TYPES.has(type)) {
+        clearedTiles += 1;
+      }
+    });
+  });
+  return {
+    forest: forestTiles * areaPerTile,
+    cleared: clearedTiles * areaPerTile
+  };
+}
+
+function ensureSiteCapacities(location) {
+  if (!location) return location;
+  if (location.siteCapacities && typeof location.siteCapacities === 'object') {
+    return location;
+  }
+  const capacities = computeSiteCapacities(location.map);
+  location.siteCapacities = capacities;
+  if (location.id) {
+    store.updateItem('locations', { id: location.id, siteCapacities: capacities });
+  }
+  return location;
+}
 
 export function generateLocation(id, biome, season = store.time.season, seed = Date.now()) {
   const features = getBiome(biome)?.features || [];
@@ -10,11 +59,29 @@ export function generateLocation(id, biome, season = store.time.season, seed = D
   const height = DEFAULT_MAP_HEIGHT;
   const { xStart, yStart } = computeCenteredStart(width, height);
   const map = generateColorMap(biome, seed, xStart, yStart, width, height, season);
-  const location = { id, biome, features, pointsOfInterest, map };
+  const siteCapacities = computeSiteCapacities(map);
+  const location = { id, biome, features, pointsOfInterest, map, siteCapacities };
   store.addItem('locations', location);
   return location;
 }
 
 export function allLocations() {
-  return [...store.locations.values()];
+  return [...store.locations.values()].map(entry => ensureSiteCapacities(entry));
+}
+
+export function getLocationSiteCapacities(locationId) {
+  if (!locationId) {
+    const first = allLocations()[0];
+    return (first && ensureSiteCapacities(first).siteCapacities) || { forest: 0, cleared: 0 };
+  }
+  const location = store.getItem('locations', locationId);
+  if (!location) return { forest: 0, cleared: 0 };
+  return ensureSiteCapacities(location).siteCapacities || { forest: 0, cleared: 0 };
+}
+
+export function ensureLocationSiteCapacities(locationId) {
+  if (!locationId) return;
+  const location = store.getItem('locations', locationId);
+  if (!location) return;
+  ensureSiteCapacities(location);
 }


### PR DESCRIPTION
## Summary
- compute per-location forest and cleared site capacity so structures respect available space
- extend building catalog entries with site footprints, crafted good requirements, and explicit core components
- update construction evaluation and UI to highlight site usage, core structure materials, and staged crafted needs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e2c465492083259ea04ad5fb1745e1