### PR TITLE
Add player job dropdown and time lapse controls

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -60,7 +60,8 @@ function startGame(settings = {}) {
   store.player = {
     locationId: 'loc1',
     x: spawnX,
-    y: spawnY
+    y: spawnY,
+    jobId: 'survey'
   };
   unlockTechnology({ id: 'basic-tools', name: 'Basic Tools' });
   refreshBuildingUnlocks();

--- a/src/state.js
+++ b/src/state.js
@@ -1,3 +1,5 @@
+const DEFAULT_PLAYER_JOB = 'survey';
+
 class DataStore {
   constructor() {
     this.buildings = new Map();
@@ -7,7 +9,7 @@ class DataStore {
     this.locations = new Map();
     this.technologies = new Map();
     this.proficiencies = new Map();
-    this.player = { locationId: null, x: 0, y: 0 };
+    this.player = { locationId: null, x: 0, y: 0, jobId: DEFAULT_PLAYER_JOB };
     this.time = { day: 1, month: 1, year: 410, hour: 6, season: 'Thawbound', weather: 'Clear' };
     this.difficulty = 'normal';
     this.jobs = {};
@@ -98,7 +100,8 @@ class DataStore {
     this.player = {
       locationId: savedPlayer.locationId ?? null,
       x: Number.isFinite(savedPlayer.x) ? Math.trunc(savedPlayer.x) : 0,
-      y: Number.isFinite(savedPlayer.y) ? Math.trunc(savedPlayer.y) : 0
+      y: Number.isFinite(savedPlayer.y) ? Math.trunc(savedPlayer.y) : 0,
+      jobId: typeof savedPlayer.jobId === 'string' && savedPlayer.jobId ? savedPlayer.jobId : DEFAULT_PLAYER_JOB
     };
     const savedTime = data.time || {};
     this.time = {


### PR DESCRIPTION
## Summary
- replace the explorer action buttons with a job focus dropdown and daylight-aware time lapse controls that include random variance
- persist the explorer's job assignment in saved data and update movement to record position immediately, preventing location resets after refresh

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2cc3bb01c8325b90442ac8c53c241