### PR TITLE
Add tile information panel with narrative context

### DIFF
--- a/src/buildings.js
+++ b/src/buildings.js
@@ -382,7 +382,7 @@ function nextBuildingId() {
   return `bld-${store.buildingSeq}`;
 }
 
-export function beginConstruction(typeId, { workers, locationId } = {}) {
+export function beginConstruction(typeId, { workers, locationId, x = null, y = null } = {}) {
   const type = buildingTypes.get(typeId);
   if (!type) throw new Error(`Unknown building type ${typeId}`);
   const evaluation = evaluateBuilding(typeId);
@@ -400,6 +400,8 @@ export function beginConstruction(typeId, { workers, locationId } = {}) {
   const normalizedSiteCategory = siteCategory ? String(siteCategory).toLowerCase() : null;
   const siteSurfaceArea = type.stats.site?.surfaceArea || 0;
   const coreComponentId = type.stats.coreComponent?.id || null;
+  const hasCoords = Number.isFinite(x) && Number.isFinite(y);
+  const tileCoords = hasCoords ? { x: Math.trunc(x), y: Math.trunc(y) } : null;
 
   const projectId = nextBuildingId();
   const project = {
@@ -416,7 +418,8 @@ export function beginConstruction(typeId, { workers, locationId } = {}) {
     coreResources,
     coreComponentId,
     siteCategory: normalizedSiteCategory,
-    siteSurfaceArea
+    siteSurfaceArea,
+    tile: tileCoords
   };
   store.addItem('buildings', project);
 
@@ -451,7 +454,8 @@ export function beginConstruction(typeId, { workers, locationId } = {}) {
         taskComplexity: baseComplexity,
         effortHours: totalLabor,
         proficiencyId: 'construction',
-        taskId: `construction:${typeId}`
+        taskId: `construction:${typeId}`,
+        tile: tileCoords
       }
     }
   };

--- a/src/gathering.js
+++ b/src/gathering.js
@@ -232,6 +232,19 @@ const BASE_HABITAT_ITEMS = [
 
 const HABITAT_ITEMS = [...BASE_HABITAT_ITEMS, ...STURDY_TREE_STICK_ITEMS];
 
+export function getHabitatProspects(terrain) {
+  if (!terrain) return [];
+  const normalized = String(terrain).trim().toLowerCase();
+  if (!normalized) return [];
+  return HABITAT_ITEMS.filter(item => item.habitats.includes(normalized)).map(item => ({
+    id: item.id,
+    resource: item.resource,
+    encounterName: item.encounterName || item.resource,
+    type: item.type,
+    toolsRequired: Array.isArray(item.toolsRequired) ? [...item.toolsRequired] : []
+  }));
+}
+
 export const STURDY_STICK_RESOURCES = STURDY_TREE_STICK_ITEMS.map(item => item.resource);
 
 function ensureGatherStore() {


### PR DESCRIPTION
## Summary
- replace the construction status and orders board with a narrative tile information panel that highlights terrain, stockpiles, gatherable prospects, and nearby structures
- track construction projects on specific tiles and surface their labor and material progress inside collapsible details
- expose gathering habitat prospects so the tile panel can describe potential resources

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2d156b5f8832590bb2743ec197bf3