### PR TITLE
Adjust job tooltip text formatting

### DIFF
--- a/src/mapView.js
+++ b/src/mapView.js
@@ -923,12 +923,14 @@ export function createMapView(container, {
     }
 
     if (jobMetaLine) {
-      const metaParts = [`Assigned ${selected.assigned}`];
+      const metaParts = [];
       if (Number.isFinite(selected.capacity)) {
-        metaParts.push(`Capacity ${selected.capacity}`);
+        metaParts.push(`Assigned ${selected.assigned}/${selected.capacity}`);
+      } else {
+        metaParts.push(`Assigned ${selected.assigned}`);
       }
       if (Number.isFinite(selected.workdayHours)) {
-        metaParts.push(`${selected.workdayHours}h day`);
+        metaParts.push(`${selected.workdayHours}h`);
       }
       if (Number.isFinite(jobSelectorState.laborers)) {
         metaParts.push(`${jobSelectorState.laborers} laborers free`);


### PR DESCRIPTION
## Summary
- update job tooltip metadata to display assigned capacity as a combined value
- simplify workday hours text by removing the trailing day label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3350d87548325a7f0e28be2609ff7