### PR TITLE
Improve setup map zoom behavior and add terrain color fills

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -15,6 +15,14 @@ export const TERRAIN_SYMBOLS = {
   stone: '🪨'
 };
 
+export const TERRAIN_COLORS = {
+  water: '#2d7ff9',
+  open: '#facc15',
+  forest: '#16a34a',
+  ore: '#f97316',
+  stone: '#94a3b8'
+};
+
 export function computeCenteredStart(width = DEFAULT_MAP_WIDTH, height = DEFAULT_MAP_HEIGHT, focusX = 0, focusY = 0) {
   const normalizedWidth = Math.max(1, Math.trunc(width));
   const normalizedHeight = Math.max(1, Math.trunc(height));

--- a/src/ui.js
+++ b/src/ui.js
@@ -314,6 +314,7 @@ export function initSetupUI(onStart) {
     showControls: true,
     showLegend: false,
     idPrefix: 'setup-map',
+    useTerrainColors: true,
     fetchMap: ({ xStart, yStart, width, height, seed, season, viewport, context }) => {
       const biomeId = context?.biomeId || biomeSelect.select.value;
       const nextSeed = seed ?? mapSeed;


### PR DESCRIPTION
## Summary
- update the map view zoom handling so resizing the viewport fetches additional tiles and keeps zoom controls accurate
- add optional terrain color fills for tiles and enable the feature on the setup map to improve terrain legibility when zoomed out

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3e559eaa88325bc47a2714546135d