### PR TITLE
Adjust map zoom controls and recentering

### DIFF
--- a/src/mapView.js
+++ b/src/mapView.js
@@ -347,6 +347,7 @@ export function createMapView(container, {
 
     state.viewport.width = nextWidth;
     state.viewport.height = nextHeight;
+    state.home = computeHomeStart(state.focus);
 
     if (!widthChanged && !heightChanged) {
       if (forceFetch) {
@@ -905,10 +906,10 @@ export function createMapView(container, {
     zoomControls.appendChild(zoomInButton);
 
     zoomOutButton.addEventListener('click', () => {
-      zoomBy(-0.2);
+      zoomBy(-0.1);
     });
     zoomInButton.addEventListener('click', () => {
-      zoomBy(0.2);
+      zoomBy(0.1);
     });
     zoomResetButton.addEventListener('click', () => {
       resetZoom();
@@ -2468,6 +2469,7 @@ export function createMapView(container, {
   }
 
   function centerMap(options = {}) {
+    state.home = computeHomeStart(state.focus);
     updateViewportStart(state.home.xStart, state.home.yStart, options);
   }
 


### PR DESCRIPTION
## Summary
- update the zoom controls to step in 10% increments for finer adjustment
- recompute the map home position during zoom and recenter actions so the navigation grid centers correctly at (0,0)

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e41d260d1083258cbd0dcac74295b4