### PR TITLE
Revamp landing screen with new styling and interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Fantasy Survival</title>
+  <link rel="stylesheet" href="styles/landing.css" id="landing-theme">
   <style>
     :root {
       --bg-color: #fff;

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,14 @@ import { initTopMenu, initBottomMenu } from './menu.js';
 import { resetToDawn, getSeasonDetails, getSeasonForMonth, randomDarkAgeYear } from './time.js';
 import { resetOrders } from './orders.js';
 
+function removeLandingTheme() {
+  document.body.classList.remove('landing-active');
+  const landingLink = document.getElementById('landing-theme');
+  if (landingLink && landingLink.parentElement) {
+    landingLink.parentElement.removeChild(landingLink);
+  }
+}
+
 function startGame(settings = {}) {
   const diff = settings.difficulty || 'normal';
   const cfg = difficultySettings[diff];
@@ -79,6 +87,7 @@ function startGame(settings = {}) {
   saveGame();
   const setupDiv = document.getElementById('setup');
   if (setupDiv) setupDiv.style.display = 'none';
+  removeLandingTheme();
   initGameUI();
 }
 
@@ -94,6 +103,7 @@ function init() {
   } else {
     const setupDiv = document.getElementById('setup');
     if (setupDiv) setupDiv.style.display = 'none';
+    removeLandingTheme();
     initGameUI();
   }
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,119 +1,194 @@
-// Temporary UI module to set up initial game parameters.
-// Provides a basic form to select biome, starting season, and difficulty.
-// This module is standalone so the UI can be redesigned or replaced
-// without affecting the rest of the game logic.
-
 import { biomes, getBiome } from './biomes.js';
 import { difficulties, difficultySettings } from './difficulty.js';
 import {
   computeCenteredStart,
   DEFAULT_MAP_HEIGHT,
   DEFAULT_MAP_WIDTH,
-  generateColorMap,
-  TERRAIN_SYMBOLS
+  generateColorMap
 } from './map.js';
 import { createMapView } from './mapView.js';
 
 const seasons = [
-  { id: 'Thawbound', name: 'Thawbound (Emergent thaw)' },
-  { id: 'Sunheight', name: 'Sunheight (High sun)' },
-  { id: 'Emberwane', name: 'Emberwane (Fading ember)' },
-  { id: 'Frostshroud', name: 'Frostshroud (Deep chill)' }
+  { id: 'Thawbound', label: 'Thawbound', hint: 'emergent thaw' },
+  { id: 'Sunheight', label: 'Sunheight', hint: 'high sun' },
+  { id: 'Emberwane', label: 'Emberwane', hint: 'fading ember' },
+  { id: 'Frostshroud', label: 'Frostshroud', hint: 'deep chill' }
 ];
 
-/**
- * Create a temporary setup form and call the provided callback when submitted.
- * @param {Function} onStart - callback receiving { biome, season, difficulty }
- */
+const difficultyFlavors = {
+  easy: 'forgiving',
+  normal: 'balanced',
+  hard: 'brutal'
+};
+
+const BIOME_SWATCHES = [
+  'linear-gradient(135deg, rgba(96, 115, 255, 0.45), rgba(136, 69, 255, 0.18))',
+  'linear-gradient(135deg, rgba(92, 214, 255, 0.45), rgba(73, 116, 255, 0.2))',
+  'linear-gradient(135deg, rgba(255, 191, 113, 0.45), rgba(255, 137, 191, 0.2))',
+  'linear-gradient(135deg, rgba(96, 255, 182, 0.45), rgba(60, 145, 255, 0.18))',
+  'linear-gradient(135deg, rgba(255, 120, 120, 0.45), rgba(255, 215, 132, 0.18))',
+  'linear-gradient(135deg, rgba(150, 107, 255, 0.45), rgba(255, 158, 243, 0.18))',
+  'linear-gradient(135deg, rgba(132, 232, 255, 0.45), rgba(170, 122, 255, 0.18))',
+  'linear-gradient(135deg, rgba(255, 165, 92, 0.45), rgba(109, 227, 243, 0.18))'
+];
+
+function createSeed() {
+  if (typeof crypto !== 'undefined' && crypto?.getRandomValues) {
+    return crypto.getRandomValues(new Uint32Array(1))[0].toString(36);
+  }
+  return Math.trunc(Date.now() * Math.random()).toString(36);
+}
+
+function getBiomeSwatch(id) {
+  if (!id) return BIOME_SWATCHES[0];
+  let hash = 0;
+  for (let i = 0; i < id.length; i += 1) {
+    hash = (hash * 31 + id.charCodeAt(i)) & 0xffffffff;
+  }
+  const index = Math.abs(hash) % BIOME_SWATCHES.length;
+  return BIOME_SWATCHES[index];
+}
+
 export function initSetupUI(onStart) {
   const container = document.getElementById('setup') || document.body;
+  container.innerHTML = '';
 
-  const form = document.createElement('form');
-  form.id = 'setup-form';
+  document.body.classList.add('landing-active');
 
-  const makeSelect = (labelText, options, name) => {
-    const label = document.createElement('label');
-    label.textContent = labelText + ': ';
+  const template = document.createElement('template');
+  template.innerHTML = `
+    <div class="wrap">
+      <div class="setup">
+        <div class="hero">
+          <div>
+            <div class="brand">Fantasy Survival</div>
+            <div class="sub">Settle a harsh land. Thrive through seasons. Adapt or vanish.</div>
+          </div>
+          <div class="badge badge--ok">Alpha</div>
+        </div>
 
-    const select = document.createElement('select');
-    select.name = name;
-    options.forEach(opt => {
-      const option = document.createElement('option');
-      option.value = opt.id || opt;
-      option.textContent = opt.name || opt;
-      select.appendChild(option);
-    });
+        <div class="card section" id="biome-card">
+          <div class="section__title">Biome</div>
+          <div class="grid" id="biome-grid"></div>
+          <div class="mini-map" id="biome-mini-map" aria-hidden="true"></div>
+          <div class="sub" id="biome-details"></div>
+        </div>
 
-    label.appendChild(select);
-    return { label, select };
-  };
+        <div class="card section">
+          <div class="section__title">Starting Season</div>
+          <div class="segment" id="season-seg"></div>
+        </div>
 
-  const biomeSelect = makeSelect('Biome', biomes, 'biome');
-  const seasonSelect = makeSelect('Season', seasons, 'season');
-  const diffSelect = makeSelect('Difficulty', difficulties, 'difficulty');
+        <div class="card section">
+          <div class="section__title">Difficulty</div>
+          <div class="segment" id="difficulty-seg"></div>
+          <div class="difficulty-tip" id="difficulty-tip"></div>
+        </div>
 
-  [biomeSelect, seasonSelect, diffSelect].forEach(({ label }) => {
-    form.appendChild(label);
-    form.appendChild(document.createElement('br'));
-  });
+        <div class="card section">
+          <div class="section__title">World Seed</div>
+          <div class="seed-row">
+            <input id="seed-input" class="input" placeholder="Enter seed or leave blank for random" autocomplete="off">
+            <button id="seed-apply" type="button" class="btn btn--ghost">Apply</button>
+            <button id="seed-rand" type="button" class="btn btn--ghost" aria-label="Randomize seed">🎲 Random</button>
+          </div>
+        </div>
 
-  const biomeInfo = document.createElement('p');
-  const diffInfo = document.createElement('p');
-  form.appendChild(biomeInfo);
-  form.appendChild(diffInfo);
+        <div class="card section">
+          <div class="section__title">Advanced</div>
+          <div class="cta-row">
+            <button id="toggle-adv" type="button" class="btn btn--ghost">Show Options</button>
+          </div>
+          <div id="adv" class="adv" hidden>
+            <div class="section__title">Map Preview</div>
+            <p class="sub" id="map-tip">Explore the terrain and click to choose a spawn point.</p>
+            <div id="map-preview" class="map-preview"></div>
+            <p class="sub" id="spawn-info"></p>
+          </div>
+        </div>
 
+        <div class="card cta-row">
+          <button id="randomize-all" type="button" class="btn">Randomize All</button>
+          <div class="spacer" aria-hidden="true"></div>
+          <button id="start-btn" type="button" class="btn btn--primary">Start Game</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const wrap = template.content.firstElementChild;
+  container.appendChild(wrap);
+
+  const biomeGrid = wrap.querySelector('#biome-grid');
+  const biomeDetails = wrap.querySelector('#biome-details');
+  const biomeMiniMap = wrap.querySelector('#biome-mini-map');
+  const seasonSeg = wrap.querySelector('#season-seg');
+  const difficultySeg = wrap.querySelector('#difficulty-seg');
+  const difficultyTip = wrap.querySelector('#difficulty-tip');
+  const seedInput = wrap.querySelector('#seed-input');
+  const seedApplyBtn = wrap.querySelector('#seed-apply');
+  const seedRandomBtn = wrap.querySelector('#seed-rand');
+  const toggleAdvBtn = wrap.querySelector('#toggle-adv');
+  const advPanel = wrap.querySelector('#adv');
+  const mapPreview = wrap.querySelector('#map-preview');
+  const spawnInfo = wrap.querySelector('#spawn-info');
+  const randomizeAllBtn = wrap.querySelector('#randomize-all');
+  const startBtn = wrap.querySelector('#start-btn');
+
+  const biomeTiles = [];
+  const seasonButtons = [];
+  const difficultyButtons = [];
+
+  const defaultBiome = biomes.find(b => b.id === 'temperate-deciduous') || biomes[0];
+  const defaultSeason = seasons[0];
+  const defaultDifficulty = difficulties.find(d => d.id === 'normal') || difficulties[0];
+
+  let selectedBiome = defaultBiome?.id || '';
+  let selectedSeason = defaultSeason?.id || '';
+  let selectedDifficulty = defaultDifficulty?.id || '';
+  let mapSeed = createSeed();
   let mapData = null;
-  let mapSeed = Date.now().toString();
+  let mapView = null;
   let spawnCoords = null;
   let spawnPrompt = null;
   let pendingSpawn = null;
   const spawnMarkerId = 'setup-spawn-marker';
 
-  const mapSection = document.createElement('section');
-  mapSection.style.marginTop = '12px';
-
-  const mapIntro = document.createElement('p');
-  mapIntro.textContent = 'Preview of the surrounding area rendered with emoji terrain symbols. Each icon represents one patch of terrain. Use the navigation and zoom controls to examine different parts of the map.';
-  mapSection.appendChild(mapIntro);
-
-  const spawnInfo = document.createElement('p');
-  spawnInfo.style.margin = '8px 0 0';
-  spawnInfo.style.fontStyle = 'italic';
-
-  const seedRow = document.createElement('div');
-  seedRow.style.display = 'flex';
-  seedRow.style.flexWrap = 'wrap';
-  seedRow.style.alignItems = 'center';
-  seedRow.style.gap = '6px';
-
-  const seedLabel = document.createElement('label');
-  seedLabel.textContent = 'Map Seed: ';
-  const seedInput = document.createElement('input');
-  seedInput.type = 'text';
   seedInput.value = mapSeed;
-  seedInput.size = 24;
-  seedLabel.appendChild(seedInput);
-  seedRow.appendChild(seedLabel);
 
-  const applySeedBtn = document.createElement('button');
-  applySeedBtn.type = 'button';
-  applySeedBtn.textContent = 'Apply';
-  seedRow.appendChild(applySeedBtn);
+  function setActive(list, node) {
+    list.forEach(item => {
+      item.classList.toggle('is-active', item === node);
+    });
+  }
 
-  const randomSeedBtn = document.createElement('button');
-  randomSeedBtn.type = 'button';
-  randomSeedBtn.textContent = 'Randomize';
-  seedRow.appendChild(randomSeedBtn);
+  function updateBiomeDetails() {
+    const biome = getBiome(selectedBiome);
+    if (!biome) {
+      biomeDetails.textContent = '';
+      return;
+    }
+    const features = biome.features?.length ? `Features: ${biome.features.join(', ')}.` : '';
+    biomeDetails.textContent = `${biome.name}${biome.description ? ` – ${biome.description}` : ''} ${features}`.trim();
+  }
 
-  mapSection.appendChild(seedRow);
+  function updateBiomePreview() {
+    biomeMiniMap.style.background = getBiomeSwatch(selectedBiome);
+  }
 
-  const LEGEND_LABELS = {
-    water: 'Water',
-    open: 'Open Land',
-    forest: 'Forest',
-    ore: 'Ore Deposits',
-    stone: 'Stone Outcrop'
-  };
+  function updateDifficultyInfo() {
+    if (!selectedDifficulty) {
+      difficultyTip.textContent = '';
+      return;
+    }
+    const diff = difficultySettings[selectedDifficulty];
+    const name = difficulties.find(d => d.id === selectedDifficulty)?.name || selectedDifficulty;
+    if (diff) {
+      difficultyTip.textContent = `${name}: ${diff.people} settlers, ${diff.foodDays} days of food, ${diff.firewoodDays} days of firewood.`;
+    } else {
+      difficultyTip.textContent = name;
+    }
+  }
 
   function hideSpawnPrompt() {
     if (spawnPrompt) {
@@ -132,40 +207,35 @@ export function initSetupUI(onStart) {
       spawnPrompt.setAttribute('role', 'dialog');
       spawnPrompt.setAttribute('aria-modal', 'false');
       spawnPrompt.setAttribute('aria-hidden', 'true');
-      Object.assign(spawnPrompt.style, {
-        position: 'absolute',
-        display: 'none',
-        flexDirection: 'column',
-        gap: '8px',
-        background: 'var(--bg-color, #fff)',
-        color: 'inherit',
-        border: '1px solid var(--map-border, #ccc)',
-        borderRadius: '10px',
-        padding: '12px 16px',
-        boxShadow: '0 8px 16px rgba(0, 0, 0, 0.2)',
-        zIndex: '10',
-        minWidth: '140px'
-      });
+      spawnPrompt.style.position = 'absolute';
+      spawnPrompt.style.display = 'none';
+      spawnPrompt.style.flexDirection = 'column';
+      spawnPrompt.style.gap = '8px';
+      spawnPrompt.style.padding = '12px 16px';
+      spawnPrompt.style.borderRadius = '12px';
+      spawnPrompt.style.boxShadow = '0 12px 24px rgba(0, 0, 0, 0.45)';
+      spawnPrompt.style.minWidth = '150px';
+
       const question = document.createElement('p');
       question.dataset.role = 'spawn-question';
       question.style.margin = '0';
       question.style.fontWeight = '600';
-      question.textContent = 'Spawn here?';
       spawnPrompt.appendChild(question);
 
       const buttonRow = document.createElement('div');
       buttonRow.style.display = 'flex';
-      buttonRow.style.gap = '8px';
       buttonRow.style.justifyContent = 'flex-end';
+      buttonRow.style.gap = '8px';
+
+      const noBtn = document.createElement('button');
+      noBtn.type = 'button';
+      noBtn.textContent = 'No';
+      noBtn.dataset.role = 'spawn-no';
 
       const yesBtn = document.createElement('button');
       yesBtn.type = 'button';
       yesBtn.textContent = 'Yes';
       yesBtn.dataset.role = 'spawn-yes';
-      const noBtn = document.createElement('button');
-      noBtn.type = 'button';
-      noBtn.textContent = 'No';
-      noBtn.dataset.role = 'spawn-no';
 
       buttonRow.appendChild(noBtn);
       buttonRow.appendChild(yesBtn);
@@ -248,19 +318,6 @@ export function initSetupUI(onStart) {
     };
   }
 
-  function setSpawnCoords(coords = {}, options = {}) {
-    if (!coords) return;
-    const x = Number.isFinite(coords.x) ? Math.trunc(coords.x) : null;
-    const y = Number.isFinite(coords.y) ? Math.trunc(coords.y) : null;
-    if (x === null || y === null) return;
-    spawnCoords = { x, y };
-    if (!options.silent) {
-      hideSpawnPrompt();
-    }
-    updateSpawnMarker();
-    updateSpawnInfo();
-  }
-
   function getTerrainAt(map, coords = {}) {
     if (!map?.types?.length) return null;
     const xStart = Number.isFinite(map.xStart) ? Math.trunc(map.xStart) : 0;
@@ -275,20 +332,14 @@ export function initSetupUI(onStart) {
 
   function describeTerrain(type) {
     if (!type) return '';
-    return LEGEND_LABELS[type] || type;
-  }
-
-  function updateSpawnInfo() {
-    if (!spawnInfo) return;
-    if (!spawnCoords) {
-      spawnInfo.textContent = 'Click the map to choose your starting position.';
-      return;
-    }
-    const terrain = describeTerrain(getTerrainAt(mapData, spawnCoords));
-    const coordsText = `(${spawnCoords.x}, ${spawnCoords.y})`;
-    spawnInfo.textContent = terrain
-      ? `Chosen spawn point ${coordsText} – ${terrain}.`
-      : `Chosen spawn point ${coordsText}.`;
+    const labels = {
+      water: 'Water',
+      open: 'Open Land',
+      forest: 'Forest',
+      ore: 'Ore Deposits',
+      stone: 'Stone Outcrop'
+    };
+    return labels[type] || type;
   }
 
   function updateSpawnMarker() {
@@ -309,16 +360,115 @@ export function initSetupUI(onStart) {
     mapView.setMarkers(markers);
   }
 
-  const mapView = createMapView(mapSection, {
-    legendLabels: LEGEND_LABELS,
+  function updateSpawnInfo() {
+    if (!spawnInfo) return;
+    if (!spawnCoords) {
+      spawnInfo.textContent = 'Click the map to choose your starting position.';
+      return;
+    }
+    const terrain = describeTerrain(getTerrainAt(mapData, spawnCoords));
+    const coordsText = `(${spawnCoords.x}, ${spawnCoords.y})`;
+    spawnInfo.textContent = terrain
+      ? `Chosen spawn point ${coordsText} – ${terrain}.`
+      : `Chosen spawn point ${coordsText}.`;
+  }
+
+  function setSpawnCoords(coords = {}, options = {}) {
+    if (!coords) return;
+    const x = Number.isFinite(coords.x) ? Math.trunc(coords.x) : null;
+    const y = Number.isFinite(coords.y) ? Math.trunc(coords.y) : null;
+    if (x === null || y === null) return;
+    spawnCoords = { x, y };
+    if (!options.silent) {
+      hideSpawnPrompt();
+    }
+    updateSpawnMarker();
+    updateSpawnInfo();
+  }
+
+  function renderMapPreview() {
+    if (!mapData || !mapView) return;
+    hideSpawnPrompt();
+    mapView.setMap(mapData, {
+      biomeId: selectedBiome,
+      seed: mapData?.seed ?? mapSeed,
+      season: mapData?.season ?? selectedSeason
+    });
+    updateSpawnMarker();
+    updateSpawnInfo();
+  }
+
+  function generatePreview() {
+    if (!selectedBiome || !mapPreview) return;
+    const width = DEFAULT_MAP_WIDTH;
+    const height = DEFAULT_MAP_HEIGHT;
+    const { xStart, yStart } = computeCenteredStart(width, height);
+    mapData = generateColorMap(
+      selectedBiome,
+      mapSeed,
+      xStart,
+      yStart,
+      width,
+      height,
+      selectedSeason
+    );
+    const defaultSpawn = computeDefaultSpawn(mapData);
+    if (defaultSpawn) {
+      setSpawnCoords(defaultSpawn, { silent: true });
+    } else {
+      spawnCoords = null;
+      updateSpawnMarker();
+      updateSpawnInfo();
+    }
+    renderMapPreview();
+  }
+
+  function applySelection(key, value) {
+    if (!value) return;
+    switch (key) {
+      case 'biome':
+        if (value === selectedBiome) return;
+        selectedBiome = value;
+        updateBiomeDetails();
+        updateBiomePreview();
+        generatePreview();
+        break;
+      case 'season':
+        if (value === selectedSeason) return;
+        selectedSeason = value;
+        generatePreview();
+        break;
+      case 'diff':
+        if (value === selectedDifficulty) return;
+        selectedDifficulty = value;
+        updateDifficultyInfo();
+        break;
+      case 'seed':
+        mapSeed = value;
+        seedInput.value = mapSeed;
+        generatePreview();
+        break;
+      default:
+        break;
+    }
+  }
+
+  mapView = createMapView(mapPreview, {
+    legendLabels: {
+      water: 'Water',
+      open: 'Open Land',
+      forest: 'Forest',
+      ore: 'Ore Deposits',
+      stone: 'Stone Outcrop'
+    },
     showControls: true,
     showLegend: false,
     idPrefix: 'setup-map',
     useTerrainColors: true,
-    fetchMap: ({ xStart, yStart, width, height, seed, season, viewport, context }) => {
-      const biomeId = context?.biomeId || biomeSelect.select.value;
+    fetchMap: ({ xStart, yStart, width, height, seed, season, viewport }) => {
+      const biomeId = selectedBiome;
       const nextSeed = seed ?? mapSeed;
-      const nextSeason = season ?? seasonSelect.select.value;
+      const nextSeason = season ?? selectedSeason;
       return generateColorMap(
         biomeId,
         nextSeed,
@@ -341,113 +491,159 @@ export function initSetupUI(onStart) {
     }
   });
 
-  mapSection.appendChild(spawnInfo);
-  updateSpawnInfo();
-
-  form.appendChild(mapSection);
-
-  const startBtn = document.createElement('button');
-  startBtn.type = 'submit';
-  startBtn.textContent = 'Start';
-  form.appendChild(startBtn);
-
-  container.appendChild(form);
-
-  function updateInfo() {
-    const biome = getBiome(biomeSelect.select.value);
-    if (biome) {
-      const desc = biome.description ? `${biome.description} ` : '';
-      const features = biome.features?.length ? `Features: ${biome.features.join(', ')}.` : '';
-      biomeInfo.textContent = `${biome.name}: ${desc}${features}`;
-    } else {
-      biomeInfo.textContent = '';
-    }
-
-    const diffId = diffSelect.select.value;
-    const diff = difficultySettings[diffId];
-    const diffName = diffSelect.select.options[diffSelect.select.selectedIndex]?.textContent || diffId;
-    if (diff) {
-      diffInfo.textContent = `${diffName} difficulty – ${diff.people} settlers, ${diff.foodDays} days of food, ${diff.firewoodDays} days of firewood.`;
-    } else {
-      diffInfo.textContent = '';
-    }
-  }
-
-  function renderMapPreview() {
-    if (!mapData) return;
-    hideSpawnPrompt();
-    mapView.setMap(mapData, {
-      biomeId: biomeSelect.select.value,
-      seed: mapData?.seed ?? mapSeed,
-      season: mapData?.season ?? seasonSelect.select.value
+  biomes.forEach((biome, index) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'tile col-4';
+    button.dataset.biome = biome.id;
+    button.innerHTML = `
+      <div class="tile__name">${biome.name}</div>
+      <div class="tile__desc">${biome.description || ''}</div>
+    `;
+    button.addEventListener('click', () => {
+      setActive(biomeTiles, button);
+      applySelection('biome', biome.id);
     });
-    updateSpawnMarker();
-    updateSpawnInfo();
+    if (!selectedBiome && index === 0) {
+      selectedBiome = biome.id;
+    }
+    biomeTiles.push(button);
+    biomeGrid.appendChild(button);
+  });
+
+  seasons.forEach((season, index) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'seg';
+    button.dataset.season = season.id;
+    button.innerHTML = season.hint
+      ? `${season.label} <span class="hint">${season.hint}</span>`
+      : season.label;
+    button.addEventListener('click', () => {
+      setActive(seasonButtons, button);
+      applySelection('season', season.id);
+    });
+    if (!selectedSeason && index === 0) {
+      selectedSeason = season.id;
+    }
+    seasonButtons.push(button);
+    seasonSeg.appendChild(button);
+  });
+
+  difficulties.forEach((diff, index) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'seg';
+    button.dataset.diff = diff.id;
+    const flavor = difficultyFlavors[diff.id] || '';
+    button.innerHTML = flavor
+      ? `${diff.name} <span class="hint">${flavor}</span>`
+      : diff.name;
+    button.addEventListener('click', () => {
+      setActive(difficultyButtons, button);
+      applySelection('diff', diff.id);
+    });
+    if (!selectedDifficulty && index === 0) {
+      selectedDifficulty = diff.id;
+    }
+    difficultyButtons.push(button);
+    difficultySeg.appendChild(button);
+  });
+
+  function selectBiome(id) {
+    const tile = biomeTiles.find(item => item.dataset.biome === id) || biomeTiles[0];
+    if (!tile) return;
+    setActive(biomeTiles, tile);
+    applySelection('biome', tile.dataset.biome);
   }
 
-  function generatePreview() {
-    const width = DEFAULT_MAP_WIDTH;
-    const height = DEFAULT_MAP_HEIGHT;
-    const { xStart, yStart } = computeCenteredStart(width, height);
-    mapData = generateColorMap(
-      biomeSelect.select.value,
-      mapSeed,
-      xStart,
-      yStart,
-      width,
-      height,
-      seasonSelect.select.value
-    );
-    const defaultSpawn = computeDefaultSpawn(mapData);
-    if (defaultSpawn) {
-      setSpawnCoords(defaultSpawn, { silent: true });
+  function selectSeason(id) {
+    const seg = seasonButtons.find(item => item.dataset.season === id) || seasonButtons[0];
+    if (!seg) return;
+    setActive(seasonButtons, seg);
+    applySelection('season', seg.dataset.season);
+  }
+
+  function selectDifficulty(id) {
+    const seg = difficultyButtons.find(item => item.dataset.diff === id) || difficultyButtons[0];
+    if (!seg) return;
+    setActive(difficultyButtons, seg);
+    applySelection('diff', seg.dataset.diff);
+  }
+
+  function selectSeed(seed) {
+    applySelection('seed', seed);
+  }
+
+  selectBiome(selectedBiome);
+  selectSeason(selectedSeason);
+  selectDifficulty(selectedDifficulty);
+  updateBiomeDetails();
+  updateBiomePreview();
+  updateDifficultyInfo();
+  selectSeed(mapSeed);
+
+  seedApplyBtn.addEventListener('click', () => {
+    const value = seedInput.value.trim();
+    selectSeed(value || createSeed());
+  });
+
+  seedRandomBtn.addEventListener('click', () => {
+    const seed = createSeed();
+    selectSeed(seed);
+  });
+
+  seedInput.addEventListener('keydown', event => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      seedApplyBtn.click();
+    }
+  });
+
+  toggleAdvBtn.addEventListener('click', () => {
+    const isHidden = advPanel.hasAttribute('hidden');
+    if (isHidden) {
+      advPanel.removeAttribute('hidden');
+      toggleAdvBtn.textContent = 'Hide Options';
     } else {
-      spawnCoords = null;
-      updateSpawnMarker();
-      updateSpawnInfo();
-    }
-    renderMapPreview();
-  }
-
-  applySeedBtn.addEventListener('click', () => {
-    mapSeed = seedInput.value.trim() || Date.now().toString();
-    seedInput.value = mapSeed;
-    generatePreview();
-  });
-
-  randomSeedBtn.addEventListener('click', () => {
-    mapSeed = Date.now().toString();
-    seedInput.value = mapSeed;
-    generatePreview();
-  });
-
-  seedInput.addEventListener('keydown', e => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      applySeedBtn.click();
+      advPanel.setAttribute('hidden', '');
+      toggleAdvBtn.textContent = 'Show Options';
     }
   });
 
-  biomeSelect.select.addEventListener('change', () => {
-    updateInfo();
-    generatePreview();
-  });
-  seasonSelect.select.addEventListener('change', generatePreview);
-  diffSelect.select.addEventListener('change', updateInfo);
+  randomizeAllBtn.addEventListener('click', () => {
+    if (biomeTiles.length) {
+      const pick = biomeTiles[Math.floor(Math.random() * biomeTiles.length)];
+      setActive(biomeTiles, pick);
+      applySelection('biome', pick.dataset.biome);
+    }
 
-  form.addEventListener('submit', e => {
-    e.preventDefault();
-    applySeedBtn.click();
+    if (seasonButtons.length) {
+      const pick = seasonButtons[Math.floor(Math.random() * seasonButtons.length)];
+      setActive(seasonButtons, pick);
+      applySelection('season', pick.dataset.season);
+    }
+
+    if (difficultyButtons.length) {
+      const pick = difficultyButtons[Math.floor(Math.random() * difficultyButtons.length)];
+      setActive(difficultyButtons, pick);
+      applySelection('diff', pick.dataset.diff);
+    }
+
+    selectSeed(createSeed());
+  });
+
+  startBtn.addEventListener('click', () => {
+    const seed = seedInput.value.trim();
+    if (seed && seed !== mapSeed) {
+      selectSeed(seed);
+    }
     onStart({
-      biome: biomeSelect.select.value,
-      season: seasonSelect.select.value,
-      difficulty: diffSelect.select.value,
+      biome: selectedBiome,
+      season: selectedSeason,
+      difficulty: selectedDifficulty,
       seed: mapSeed,
       spawn: spawnCoords ? { ...spawnCoords } : null
     });
   });
-
-  updateInfo();
-  generatePreview();
 }
-

--- a/styles/landing.css
+++ b/styles/landing.css
@@ -1,0 +1,350 @@
+:root {
+  --bg: #0f0f14;
+  --bg-2: #14141c;
+  --card: #14161fdd;
+  --panel: #10121acc;
+  --stroke: #26293a;
+  --muted: #a9aec6;
+  --text: #eef0ff;
+  --accent: #c46df3;
+  --accent-2: #6de3f3;
+  --ok: #86f3c4;
+  --warn: #ffd370;
+  --radius: 18px;
+  --blur: 12px;
+  --shadow: 0 12px 36px rgba(0, 0, 0, 0.4);
+}
+
+body.landing-active {
+  margin: 0;
+  color: var(--text);
+  font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial,
+    "Apple Color Emoji", "Segoe UI Emoji";
+  background:
+    radial-gradient(1100px 700px at 15% -10%, #1b1630 0%, transparent 60%),
+    radial-gradient(900px 600px at 120% 110%, #0e2b33 0%, transparent 55%),
+    linear-gradient(180deg, var(--bg), var(--bg-2));
+}
+
+body.landing-active .wrap {
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+body.landing-active .setup {
+  width: min(980px, 100%);
+  display: grid;
+  gap: 18px;
+}
+
+body.landing-active .hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+body.landing-active .brand {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: 0.4px;
+}
+
+body.landing-active .sub {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+body.landing-active .card {
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius);
+  backdrop-filter: blur(var(--blur));
+  box-shadow: var(--shadow);
+  padding: 18px;
+}
+
+body.landing-active .section {
+  display: grid;
+  gap: 12px;
+}
+
+body.landing-active .section__title {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  color: #cfd3ec;
+}
+
+body.landing-active .badge {
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid #2b2e41;
+  color: #cdd2ec;
+}
+
+body.landing-active .badge--ok {
+  background: #10261f;
+}
+
+body.landing-active .badge--warn {
+  background: #2b1f0f;
+}
+
+body.landing-active .segment {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+body.landing-active .seg {
+  --pad: 10px 14px;
+  --bg: #0f1117;
+  --bd: #2b2e41;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: var(--pad);
+  border-radius: 12px;
+  background: var(--bg);
+  border: 1px solid var(--bd);
+  cursor: pointer;
+  user-select: none;
+  transition: transform 0.05s ease, border 0.15s ease, box-shadow 0.15s ease;
+}
+
+body.landing-active .seg:hover {
+  border-color: #3a3f57;
+}
+
+body.landing-active .seg.is-active {
+  background: linear-gradient(180deg, #22263a, #1a1e31);
+  border-color: #585eff;
+  box-shadow: 0 0 0 3px #585eff33;
+}
+
+body.landing-active .seg .hint {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+body.landing-active .grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(12, 1fr);
+}
+
+body.landing-active .col-12 {
+  grid-column: span 12;
+}
+
+body.landing-active .col-6 {
+  grid-column: span 6;
+}
+
+body.landing-active .col-4 {
+  grid-column: span 4;
+}
+
+@media (max-width: 920px) {
+  body.landing-active .col-6,
+  body.landing-active .col-4 {
+    grid-column: span 12;
+  }
+}
+
+body.landing-active .tile {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border-radius: 14px;
+  cursor: pointer;
+  background: #0f1117;
+  border: 1px solid #2b2e41;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+body.landing-active .tile:hover {
+  border-color: #3a3f57;
+}
+
+body.landing-active .tile.is-active {
+  background: linear-gradient(180deg, #1e2134, #161a2a);
+  border-color: #585eff;
+  box-shadow: 0 0 0 3px #585eff33;
+}
+
+body.landing-active .tile__name {
+  font-weight: 700;
+}
+
+body.landing-active .tile__desc {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+body.landing-active .seed-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+body.landing-active .input {
+  flex: 1 1 260px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: #0f1117;
+  color: var(--text);
+  border: 1px solid #2b2e41;
+  outline: none;
+}
+
+body.landing-active .input:focus {
+  border-color: #585eff;
+  box-shadow: 0 0 0 3px #585eff33;
+}
+
+body.landing-active .btn {
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  border: 1px solid #30344a;
+  color: #e9ecff;
+  background: linear-gradient(180deg, #2a2f42, #1c2034);
+  transition: filter 0.15s ease;
+}
+
+body.landing-active .btn:hover {
+  filter: brightness(1.05);
+}
+
+body.landing-active .btn--ghost {
+  background: transparent;
+}
+
+body.landing-active .btn--primary {
+  background: linear-gradient(180deg, var(--accent), #8a46d2);
+  border-color: #7e40c2;
+}
+
+body.landing-active .btn--ok {
+  background: linear-gradient(180deg, #3eae88, #2c8a6c);
+  border-color: #2c8a6c;
+}
+
+body.landing-active .cta-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+body.landing-active .adv {
+  background: var(--panel);
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  padding: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+body.landing-active .adv[hidden] {
+  display: none;
+}
+
+body.landing-active .mini-map {
+  position: relative;
+  min-height: 140px;
+  border-radius: 14px;
+  border: 1px solid #262a3d;
+  background: linear-gradient(140deg, rgba(92, 121, 255, 0.2), rgba(149, 92, 255, 0.08));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+
+body.landing-active .mini-map::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.14), transparent 60%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+body.landing-active .map-preview {
+  position: relative;
+  border-radius: 16px;
+  border: 1px solid rgba(88, 94, 255, 0.22);
+  background: rgba(10, 12, 20, 0.85);
+  overflow: hidden;
+  min-height: 320px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+body.landing-active .difficulty-tip {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+body.landing-active .spacer {
+  flex: 1 1 auto;
+}
+
+body.landing-active .spawn-confirm {
+  background: var(--panel);
+  border: 1px solid var(--stroke);
+  color: var(--text);
+}
+
+body.landing-active .spawn-confirm button {
+  border-radius: 10px;
+  border: 1px solid #2b2e41;
+  background: rgba(15, 17, 23, 0.8);
+  color: inherit;
+  cursor: pointer;
+  padding: 6px 10px;
+}
+
+body.landing-active .spawn-confirm button:hover {
+  border-color: #3a3f57;
+}
+
+body.landing-active .map-marker--spawn {
+  filter: drop-shadow(0 0 6px rgba(133, 158, 255, 0.75));
+}
+
+body.landing-active #map-tip {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+body.landing-active .adv .grid {
+  gap: 16px;
+}
+
+body.landing-active .adv label {
+  display: grid;
+  gap: 6px;
+}
+
+body.landing-active .adv .section__title {
+  color: #d5daff;
+}
+
+body.landing-active .map-preview canvas {
+  border-radius: 16px;
+}
+
+@media (max-width: 640px) {
+  body.landing-active .wrap {
+    padding: 18px;
+  }
+  body.landing-active .map-preview {
+    min-height: 260px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated landing stylesheet and load it only for the setup experience
- rebuild the setup UI to match the new card-based layout with biome tiles, segmented controls, and enhanced map preview helpers
- remove the landing theme once the game starts or a save loads so in-game styling is unaffected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e45506fe1883258dc442a383b99659