### PR TITLE
Update creation screen dark mode theme and layout

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -59,7 +59,7 @@ export function initSetupUI(onStart) {
   template.innerHTML = `
     <div class="wrap">
       <div class="setup">
-        <div class="hero">
+        <div class="card hero">
           <div>
             <div class="brand">Fantasy Survival</div>
             <div class="sub">Settle a harsh land. Thrive through seasons. Adapt or vanish.</div>
@@ -94,17 +94,10 @@ export function initSetupUI(onStart) {
           </div>
         </div>
 
-        <div class="card section">
-          <div class="section__title">Advanced</div>
-          <div class="cta-row">
-            <button id="toggle-adv" type="button" class="btn btn--ghost">Show Options</button>
-          </div>
-          <div id="adv" class="adv" hidden>
-            <div class="section__title">Map Preview</div>
-            <p class="sub" id="map-tip">Explore the terrain and click to choose a spawn point.</p>
-            <div id="map-preview" class="map-preview"></div>
-            <p class="sub" id="spawn-info"></p>
-          </div>
+        <div class="card section map-section">
+          <p class="map-tip" id="map-tip">Explore the terrain and click to choose a spawn point.</p>
+          <div id="map-preview" class="map-preview" aria-label="World map preview"></div>
+          <p class="sub" id="spawn-info"></p>
         </div>
 
         <div class="card cta-row">
@@ -128,8 +121,6 @@ export function initSetupUI(onStart) {
   const seedInput = wrap.querySelector('#seed-input');
   const seedApplyBtn = wrap.querySelector('#seed-apply');
   const seedRandomBtn = wrap.querySelector('#seed-rand');
-  const toggleAdvBtn = wrap.querySelector('#toggle-adv');
-  const advPanel = wrap.querySelector('#adv');
   const mapPreview = wrap.querySelector('#map-preview');
   const spawnInfo = wrap.querySelector('#spawn-info');
   const randomizeAllBtn = wrap.querySelector('#randomize-all');
@@ -597,17 +588,6 @@ export function initSetupUI(onStart) {
     if (event.key === 'Enter') {
       event.preventDefault();
       seedApplyBtn.click();
-    }
-  });
-
-  toggleAdvBtn.addEventListener('click', () => {
-    const isHidden = advPanel.hasAttribute('hidden');
-    if (isHidden) {
-      advPanel.removeAttribute('hidden');
-      toggleAdvBtn.textContent = 'Hide Options';
-    } else {
-      advPanel.setAttribute('hidden', '');
-      toggleAdvBtn.textContent = 'Show Options';
     }
   });
 

--- a/styles/landing.css
+++ b/styles/landing.css
@@ -1,42 +1,84 @@
 :root {
-  --bg: #0f0f14;
-  --bg-2: #14141c;
-  --card: #14161fdd;
-  --panel: #10121acc;
-  --stroke: #26293a;
-  --muted: #a9aec6;
-  --text: #eef0ff;
-  --accent: #c46df3;
-  --accent-2: #6de3f3;
+  --navy-950: #010814;
+  --navy-900: #04142f;
+  --navy-850: #0a2144;
+  --charcoal-900: #111722;
+  --charcoal-850: #18202e;
+  --charcoal-800: #1f2737;
+  --accent: #f1d48a;
+  --accent-bright: #f7df9f;
+  --text-strong: #f7f9ff;
+  --text-muted: #bbc6de;
+  --glass-blue: rgba(11, 29, 64, 0.78);
+  --glass-blue-strong: rgba(18, 41, 82, 0.82);
+  --glass-charcoal: rgba(21, 28, 40, 0.8);
+  --glass-charcoal-strong: rgba(26, 34, 48, 0.85);
+  --glass-highlight: rgba(255, 255, 255, 0.09);
+  --border-blue: rgba(90, 134, 206, 0.42);
+  --border-charcoal: rgba(38, 48, 68, 0.6);
+  --border-bright: rgba(241, 212, 138, 0.45);
   --ok: #86f3c4;
-  --warn: #ffd370;
-  --radius: 18px;
-  --blur: 12px;
-  --shadow: 0 12px 36px rgba(0, 0, 0, 0.4);
+  --warn: #ffd77e;
+  --radius: 20px;
+  --blur: 18px;
+  --shadow: 0 24px 60px rgba(2, 8, 22, 0.55);
 }
 
 body.landing-active {
   margin: 0;
-  color: var(--text);
+  color: var(--text-strong);
   font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial,
     "Apple Color Emoji", "Segoe UI Emoji";
   background:
-    radial-gradient(1100px 700px at 15% -10%, #1b1630 0%, transparent 60%),
-    radial-gradient(900px 600px at 120% 110%, #0e2b33 0%, transparent 55%),
-    linear-gradient(180deg, var(--bg), var(--bg-2));
+    radial-gradient(1100px 700px at 15% -10%, rgba(20, 57, 128, 0.55) 0%, transparent 60%),
+    radial-gradient(900px 600px at 120% 110%, rgba(24, 33, 52, 0.6) 0%, transparent 55%),
+    linear-gradient(200deg, var(--navy-950), var(--navy-900));
 }
 
 body.landing-active .wrap {
   min-height: 100dvh;
-  display: grid;
-  place-items: center;
-  padding: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(18px, 5vw, 48px);
 }
 
 body.landing-active .setup {
-  width: min(980px, 100%);
+  width: min(960px, 100%);
   display: grid;
-  gap: 18px;
+  gap: 20px;
+  background: var(--glass-charcoal);
+  border: 1px solid var(--border-charcoal);
+  border-radius: 32px;
+  padding: clamp(20px, 4vw, 36px);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(var(--blur));
+  position: relative;
+  overflow: hidden;
+}
+
+body.landing-active .setup::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid rgba(241, 212, 138, 0.08);
+  pointer-events: none;
+}
+
+body.landing-active .setup > .card {
+  position: relative;
+  border-radius: var(--radius);
+  padding: clamp(16px, 3vw, 24px);
+  background: var(--glass-blue);
+  border: 1px solid var(--border-blue);
+  box-shadow: inset 0 0 0 1px var(--glass-highlight);
+  backdrop-filter: blur(calc(var(--blur) * 0.6));
+}
+
+body.landing-active .setup > .card:nth-of-type(even) {
+  background: var(--glass-charcoal-strong);
+  border-color: var(--border-charcoal);
 }
 
 body.landing-active .hero {
@@ -44,54 +86,53 @@ body.landing-active .hero {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  padding-block: clamp(14px, 2.5vw, 18px);
 }
 
 body.landing-active .brand {
-  font-size: 22px;
+  font-size: clamp(22px, 2.6vw, 28px);
   font-weight: 800;
   letter-spacing: 0.4px;
 }
 
 body.landing-active .sub {
-  color: var(--muted);
+  color: var(--text-muted);
   font-size: 13px;
 }
 
-body.landing-active .card {
-  background: var(--card);
-  border: 1px solid var(--stroke);
-  border-radius: var(--radius);
-  backdrop-filter: blur(var(--blur));
-  box-shadow: var(--shadow);
-  padding: 18px;
-}
-
-body.landing-active .section {
+body.landing-active .card.section {
   display: grid;
-  gap: 12px;
+  gap: 14px;
 }
 
 body.landing-active .section__title {
   font-size: 14px;
   font-weight: 700;
   letter-spacing: 0.3px;
-  color: #cfd3ec;
+  color: var(--accent);
 }
 
 body.landing-active .badge {
-  padding: 4px 8px;
+  padding: 5px 10px;
   border-radius: 999px;
   font-size: 11px;
-  border: 1px solid #2b2e41;
-  color: #cdd2ec;
+  border: 1px solid rgba(241, 212, 138, 0.3);
+  color: var(--accent-bright);
+  background: rgba(241, 212, 138, 0.12);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
 }
 
 body.landing-active .badge--ok {
-  background: #10261f;
+  background: rgba(134, 243, 196, 0.15);
+  border-color: rgba(134, 243, 196, 0.38);
+  color: #c3ffe6;
 }
 
 body.landing-active .badge--warn {
-  background: #2b1f0f;
+  background: rgba(255, 215, 126, 0.15);
+  border-color: rgba(255, 215, 126, 0.32);
+  color: #ffe7af;
 }
 
 body.landing-active .segment {
@@ -101,33 +142,33 @@ body.landing-active .segment {
 }
 
 body.landing-active .seg {
-  --pad: 10px 14px;
-  --bg: #0f1117;
-  --bd: #2b2e41;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: var(--pad);
-  border-radius: 12px;
-  background: var(--bg);
-  border: 1px solid var(--bd);
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(16, 36, 70, 0.55);
+  border: 1px solid rgba(90, 134, 206, 0.35);
+  color: var(--text-strong);
   cursor: pointer;
   user-select: none;
-  transition: transform 0.05s ease, border 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.08s ease, border 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+  backdrop-filter: blur(calc(var(--blur) * 0.35));
 }
 
 body.landing-active .seg:hover {
-  border-color: #3a3f57;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
 }
 
 body.landing-active .seg.is-active {
-  background: linear-gradient(180deg, #22263a, #1a1e31);
-  border-color: #585eff;
-  box-shadow: 0 0 0 3px #585eff33;
+  background: rgba(20, 48, 96, 0.72);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(241, 212, 138, 0.28);
 }
 
 body.landing-active .seg .hint {
-  color: var(--muted);
+  color: var(--text-muted);
   font-size: 12px;
 }
 
@@ -162,19 +203,21 @@ body.landing-active .tile {
   padding: 12px;
   border-radius: 14px;
   cursor: pointer;
-  background: #0f1117;
-  border: 1px solid #2b2e41;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  background: rgba(17, 39, 74, 0.48);
+  border: 1px solid rgba(74, 108, 168, 0.38);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+  backdrop-filter: blur(calc(var(--blur) * 0.35));
 }
 
 body.landing-active .tile:hover {
-  border-color: #3a3f57;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(241, 212, 138, 0.25);
 }
 
 body.landing-active .tile.is-active {
-  background: linear-gradient(180deg, #1e2134, #161a2a);
-  border-color: #585eff;
-  box-shadow: 0 0 0 3px #585eff33;
+  background: rgba(23, 54, 110, 0.7);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(241, 212, 138, 0.28);
 }
 
 body.landing-active .tile__name {
@@ -182,7 +225,7 @@ body.landing-active .tile__name {
 }
 
 body.landing-active .tile__desc {
-  color: var(--muted);
+  color: var(--text-muted);
   font-size: 12px;
 }
 
@@ -195,100 +238,117 @@ body.landing-active .seed-row {
 body.landing-active .input {
   flex: 1 1 260px;
   padding: 10px 12px;
-  border-radius: 12px;
-  background: #0f1117;
-  color: var(--text);
-  border: 1px solid #2b2e41;
+  border-radius: 14px;
+  background: rgba(16, 26, 42, 0.72);
+  color: var(--text-strong);
+  border: 1px solid rgba(80, 100, 140, 0.55);
   outline: none;
+  backdrop-filter: blur(calc(var(--blur) * 0.35));
+  transition: border 0.18s ease, box-shadow 0.18s ease;
 }
 
 body.landing-active .input:focus {
-  border-color: #585eff;
-  box-shadow: 0 0 0 3px #585eff33;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(241, 212, 138, 0.3);
 }
 
 body.landing-active .btn {
-  padding: 10px 14px;
-  border-radius: 12px;
+  padding: 10px 16px;
+  border-radius: 14px;
   font-weight: 700;
   cursor: pointer;
-  border: 1px solid #30344a;
-  color: #e9ecff;
-  background: linear-gradient(180deg, #2a2f42, #1c2034);
-  transition: filter 0.15s ease;
+  border: 1px solid rgba(84, 112, 164, 0.45);
+  color: var(--text-strong);
+  background: linear-gradient(160deg, rgba(22, 44, 86, 0.8), rgba(14, 28, 54, 0.75));
+  transition: filter 0.18s ease, transform 0.1s ease;
+  backdrop-filter: blur(calc(var(--blur) * 0.3));
 }
 
 body.landing-active .btn:hover {
   filter: brightness(1.05);
+  transform: translateY(-1px);
+}
+
+body.landing-active .btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 body.landing-active .btn--ghost {
-  background: transparent;
+  background: rgba(15, 28, 50, 0.4);
+  border-color: rgba(90, 134, 206, 0.32);
 }
 
 body.landing-active .btn--primary {
-  background: linear-gradient(180deg, var(--accent), #8a46d2);
-  border-color: #7e40c2;
+  background: linear-gradient(155deg, rgba(241, 212, 138, 0.9), rgba(241, 212, 138, 0.68));
+  border-color: var(--border-bright);
+  color: #11131a;
 }
 
 body.landing-active .btn--ok {
-  background: linear-gradient(180deg, #3eae88, #2c8a6c);
-  border-color: #2c8a6c;
+  background: linear-gradient(160deg, rgba(134, 243, 196, 0.85), rgba(88, 201, 156, 0.75));
+  border-color: rgba(134, 243, 196, 0.4);
+  color: #0f1d19;
 }
 
 body.landing-active .cta-row {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;
 }
 
-body.landing-active .adv {
-  background: var(--panel);
-  border: 1px solid var(--stroke);
-  border-radius: 14px;
-  padding: 14px;
-  display: grid;
-  gap: 10px;
+body.landing-active .map-section {
+  gap: 16px;
 }
 
-body.landing-active .adv[hidden] {
-  display: none;
+body.landing-active .map-tip {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
 }
 
 body.landing-active .mini-map {
   position: relative;
   min-height: 140px;
-  border-radius: 14px;
-  border: 1px solid #262a3d;
-  background: linear-gradient(140deg, rgba(92, 121, 255, 0.2), rgba(149, 92, 255, 0.08));
+  border-radius: 16px;
+  border: 1px solid rgba(84, 112, 164, 0.4);
+  background: linear-gradient(140deg, rgba(92, 121, 255, 0.18), rgba(41, 164, 255, 0.08));
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   overflow: hidden;
+  backdrop-filter: blur(calc(var(--blur) * 0.2));
 }
 
 body.landing-active .mini-map::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.14), transparent 60%);
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 60%);
   mix-blend-mode: screen;
   pointer-events: none;
 }
 
 body.landing-active .map-preview {
   position: relative;
-  border-radius: 16px;
-  border: 1px solid rgba(88, 94, 255, 0.22);
-  background: rgba(10, 12, 20, 0.85);
+  border-radius: 18px;
+  border: 1px solid rgba(96, 146, 220, 0.5);
+  background: var(--glass-blue-strong);
   overflow: hidden;
   min-height: 320px;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 24px 40px rgba(4, 10, 24, 0.5);
+  backdrop-filter: blur(calc(var(--blur) * 0.45));
+}
+
+body.landing-active .map-preview canvas {
+  border-radius: 18px;
 }
 
 body.landing-active .difficulty-tip {
   font-size: 12px;
-  color: var(--muted);
+  color: var(--text-muted);
 }
 
 body.landing-active .spacer {
@@ -296,54 +356,41 @@ body.landing-active .spacer {
 }
 
 body.landing-active .spawn-confirm {
-  background: var(--panel);
-  border: 1px solid var(--stroke);
-  color: var(--text);
+  background: var(--glass-charcoal-strong);
+  border: 1px solid var(--border-charcoal);
+  color: var(--text-strong);
+  backdrop-filter: blur(calc(var(--blur) * 0.6));
 }
 
 body.landing-active .spawn-confirm button {
-  border-radius: 10px;
-  border: 1px solid #2b2e41;
-  background: rgba(15, 17, 23, 0.8);
+  border-radius: 12px;
+  border: 1px solid rgba(84, 112, 164, 0.4);
+  background: rgba(17, 30, 52, 0.75);
   color: inherit;
   cursor: pointer;
-  padding: 6px 10px;
+  padding: 6px 12px;
+  transition: border 0.18s ease, transform 0.1s ease;
 }
 
 body.landing-active .spawn-confirm button:hover {
-  border-color: #3a3f57;
+  border-color: var(--accent);
+  transform: translateY(-1px);
 }
 
 body.landing-active .map-marker--spawn {
-  filter: drop-shadow(0 0 6px rgba(133, 158, 255, 0.75));
-}
-
-body.landing-active #map-tip {
-  font-size: 12px;
-  color: var(--muted);
-}
-
-body.landing-active .adv .grid {
-  gap: 16px;
-}
-
-body.landing-active .adv label {
-  display: grid;
-  gap: 6px;
-}
-
-body.landing-active .adv .section__title {
-  color: #d5daff;
-}
-
-body.landing-active .map-preview canvas {
-  border-radius: 16px;
+  filter: drop-shadow(0 0 8px rgba(241, 212, 138, 0.85));
 }
 
 @media (max-width: 640px) {
   body.landing-active .wrap {
     padding: 18px;
   }
+
+  body.landing-active .setup {
+    padding: 22px;
+    border-radius: 24px;
+  }
+
   body.landing-active .map-preview {
     min-height: 260px;
   }


### PR DESCRIPTION
## Summary
- restyle the creation screen with a layered deep navy, charcoal, and pale gold dark theme
- apply semi-translucent glass styling to controls and alternate card layers for contrast
- remove the advanced toggle so the map preview renders directly beneath the seed settings

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68e47f9aad3c8325ad6147a6d260510d