### PR TITLE
Tint setup children with glass backgrounds

### DIFF
--- a/styles/landing.css
+++ b/styles/landing.css
@@ -94,6 +94,12 @@ body.landing-active .setup {
   overflow: hidden;
 }
 
+body.landing-active .setup > * {
+  color: inherit;
+  background-color: rgba(16, 26, 43, 0.55);
+  background-color: color-mix(in srgb, currentColor 18%, transparent);
+}
+
 body.landing-active .setup::before {
   content: '';
   position: absolute;


### PR DESCRIPTION
## Summary
- let setup direct children inherit text color from the parent container
- apply a semi-opaque glass-like background tint to each direct child element

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5342d8f008325a758c45ce5d23296