### PR TITLE
Add landing settings panel with theme selection

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -1,5 +1,6 @@
+import { getTheme, initTheme, onThemeChange, setTheme } from './theme.js';
+
 let zoomLevel = 1;
-let theme = localStorage.getItem('theme') || 'light';
 
 let actionBar = null;
 let settingsWrapper = null;
@@ -13,6 +14,7 @@ let zoomDisplayButton = null;
 let backMenuButton = null;
 let constructionMenuButton = null;
 let listenersBound = false;
+let removeThemeListener = null;
 
 function applyZoom() {
   const content = document.getElementById('content');
@@ -24,6 +26,7 @@ function applyZoom() {
 }
 
 function updateThemeButtonVisuals() {
+  const theme = getTheme();
   const isLight = theme === 'light';
   if (themeToggleButtons.light) {
     themeToggleButtons.light.classList.toggle('active', isLight);
@@ -36,8 +39,7 @@ function updateThemeButtonVisuals() {
 }
 
 function applyTheme() {
-  document.body.className = theme;
-  localStorage.setItem('theme', theme);
+  initTheme();
   updateThemeButtonVisuals();
 }
 
@@ -192,13 +194,17 @@ function buildSettingsPanel() {
 
   themeToggleButtons = { light: null, dark: null };
 
+  if (removeThemeListener) {
+    removeThemeListener();
+    removeThemeListener = null;
+  }
+
   const themeRow = document.createElement('div');
   themeRow.className = 'theme-toggle-row';
 
   const createThemeButton = (icon, mode, label) => {
     const button = createIconControl(icon, label, () => {
-      theme = mode;
-      applyTheme();
+      setTheme(mode);
       closePanels();
     });
     button.classList.add('theme-toggle-button');
@@ -212,7 +218,7 @@ function buildSettingsPanel() {
 
   themeRow.append(themeToggleButtons.light, themeToggleButtons.dark);
   settingsPanel.appendChild(themeRow);
-  updateThemeButtonVisuals();
+  removeThemeListener = onThemeChange(updateThemeButtonVisuals, { immediate: true });
 
   const zoomRow = document.createElement('div');
   zoomRow.className = 'icon-row';

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,74 @@
+const THEME_STORAGE_KEY = 'theme';
+const VALID_THEMES = new Set(['light', 'dark']);
+const listeners = new Set();
+
+let currentTheme = (() => {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored && VALID_THEMES.has(stored)) {
+      return stored;
+    }
+  } catch (error) {
+    console.warn('Unable to access theme preference storage.', error);
+  }
+  return 'light';
+})();
+
+function applyThemeClass() {
+  if (typeof document === 'undefined' || !document.body) return;
+  document.body.classList.remove('light', 'dark');
+  document.body.classList.add(currentTheme);
+}
+
+function notifyListeners() {
+  listeners.forEach(listener => {
+    try {
+      listener(currentTheme);
+    } catch (error) {
+      console.error('Theme listener error', error);
+    }
+  });
+}
+
+export function initTheme() {
+  applyThemeClass();
+  notifyListeners();
+}
+
+export function getTheme() {
+  return currentTheme;
+}
+
+export function setTheme(nextTheme) {
+  if (!VALID_THEMES.has(nextTheme)) return;
+  if (nextTheme === currentTheme) {
+    applyThemeClass();
+    notifyListeners();
+    return;
+  }
+  currentTheme = nextTheme;
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
+  } catch (error) {
+    console.warn('Unable to persist theme preference.', error);
+  }
+  applyThemeClass();
+  notifyListeners();
+}
+
+export function onThemeChange(listener, { immediate = false } = {}) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+  listeners.add(listener);
+  if (immediate) {
+    try {
+      listener(currentTheme);
+    } catch (error) {
+      console.error('Theme listener error', error);
+    }
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -8,6 +8,7 @@ import {
   TERRAIN_COLORS
 } from './map.js';
 import { createMapView } from './mapView.js';
+import { getTheme, onThemeChange, setTheme } from './theme.js';
 
 const seasons = [
   { id: 'Thawbound', label: 'Thawbound', hint: 'emergent thaw' },
@@ -65,7 +66,54 @@ export function initSetupUI(onStart) {
             <div class="brand">Fantasy Survival</div>
             <div class="sub">Settle a harsh land. Thrive through seasons. Adapt or vanish.</div>
           </div>
-          <div class="badge badge--ok">Alpha</div>
+          <div class="hero-settings">
+            <button
+              id="landing-settings-btn"
+              type="button"
+              class="hero-settings__trigger"
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-label="Settings"
+              title="Settings"
+            >
+              ⚙️
+            </button>
+            <div
+              id="landing-settings-panel"
+              class="hero-settings__panel"
+              role="dialog"
+              aria-hidden="true"
+              aria-labelledby="landing-settings-title"
+            >
+              <div class="hero-settings__header">
+                <div class="badge badge--ok">Alpha</div>
+                <div class="hero-settings__title" id="landing-settings-title">Settings</div>
+              </div>
+              <div class="hero-settings__section">
+                <div class="hero-settings__section-title">Theme</div>
+                <div class="hero-settings__theme-row">
+                  <button
+                    type="button"
+                    class="hero-settings__theme-btn"
+                    data-theme-mode="light"
+                    aria-pressed="false"
+                  >
+                    <span aria-hidden="true">☀️</span>
+                    <span>Light</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="hero-settings__theme-btn"
+                    data-theme-mode="dark"
+                    aria-pressed="false"
+                  >
+                    <span aria-hidden="true">🌙</span>
+                    <span>Dark</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div class="card section" id="biome-card">
@@ -128,6 +176,78 @@ export function initSetupUI(onStart) {
   const spawnInfo = wrap.querySelector('#spawn-info');
   const randomizeAllBtn = wrap.querySelector('#randomize-all');
   const startBtn = wrap.querySelector('#start-btn');
+  const landingSettingsTrigger = wrap.querySelector('#landing-settings-btn');
+  const landingSettingsPanel = wrap.querySelector('#landing-settings-panel');
+  const heroSettings = wrap.querySelector('.hero-settings');
+
+  const landingThemeButtons = new Map();
+  if (landingSettingsPanel) {
+    landingSettingsPanel
+      .querySelectorAll('.hero-settings__theme-btn[data-theme-mode]')
+      .forEach(button => {
+        const mode = button.dataset.themeMode;
+        if (!mode) return;
+        landingThemeButtons.set(mode, button);
+        button.addEventListener('click', () => {
+          setTheme(mode);
+          closeLandingSettings();
+        });
+      });
+  }
+
+  function updateLandingThemeButtons() {
+    const theme = getTheme();
+    landingThemeButtons.forEach((button, mode) => {
+      const isActive = mode === theme;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', String(isActive));
+    });
+  }
+
+  function openLandingSettings() {
+    if (!landingSettingsPanel || !landingSettingsTrigger) return;
+    landingSettingsPanel.classList.add('is-open');
+    landingSettingsPanel.setAttribute('aria-hidden', 'false');
+    landingSettingsTrigger.setAttribute('aria-expanded', 'true');
+  }
+
+  function closeLandingSettings() {
+    if (!landingSettingsPanel || !landingSettingsTrigger) return;
+    landingSettingsPanel.classList.remove('is-open');
+    landingSettingsPanel.setAttribute('aria-hidden', 'true');
+    landingSettingsTrigger.setAttribute('aria-expanded', 'false');
+  }
+
+  if (landingSettingsTrigger && landingSettingsPanel && heroSettings) {
+    landingSettingsTrigger.addEventListener('click', event => {
+      event.stopPropagation();
+      if (landingSettingsPanel.classList.contains('is-open')) {
+        closeLandingSettings();
+      } else {
+        openLandingSettings();
+      }
+    });
+
+    landingSettingsPanel.addEventListener('click', event => {
+      event.stopPropagation();
+    });
+
+    document.addEventListener('click', event => {
+      if (!heroSettings.contains(event.target)) {
+        closeLandingSettings();
+      }
+    });
+
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
+        closeLandingSettings();
+      }
+    });
+  }
+
+  onThemeChange(updateLandingThemeButtons, {
+    immediate: true
+  });
 
   const biomeTiles = [];
   const seasonButtons = [];

--- a/styles/landing.css
+++ b/styles/landing.css
@@ -132,6 +132,125 @@ body.landing-active .hero {
   padding-block: clamp(14px, 2.5vw, 18px);
 }
 
+body.landing-active .hero-settings {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+body.landing-active .hero-settings__trigger {
+  border: 1px solid rgba(241, 212, 138, 0.35);
+  background: rgba(241, 212, 138, 0.12);
+  color: var(--accent-bright);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.1s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+body.landing-active .hero-settings__trigger:hover {
+  transform: translateY(-1px);
+  background: rgba(241, 212, 138, 0.18);
+  border-color: rgba(241, 212, 138, 0.5);
+}
+
+body.landing-active .hero-settings__trigger:focus-visible {
+  outline: 2px solid rgba(134, 243, 196, 0.8);
+  outline-offset: 2px;
+}
+
+body.landing-active .hero-settings__panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 220px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid var(--border-charcoal);
+  background: var(--glass-charcoal-strong);
+  box-shadow: 0 18px 42px rgba(3, 8, 18, 0.45);
+  backdrop-filter: blur(calc(var(--blur) * 0.6));
+  z-index: 15;
+}
+
+body.landing-active .hero-settings__panel.is-open {
+  display: flex;
+}
+
+body.landing-active .hero-settings__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+body.landing-active .hero-settings__title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+body.landing-active .hero-settings__section {
+  display: grid;
+  gap: 10px;
+}
+
+body.landing-active .hero-settings__section-title {
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+body.landing-active .hero-settings__theme-row {
+  display: flex;
+  gap: 8px;
+}
+
+body.landing-active .hero-settings__theme-btn {
+  flex: 1 1 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(241, 212, 138, 0.25);
+  background: rgba(15, 28, 46, 0.6);
+  color: var(--text-strong);
+  font-size: 13px;
+  cursor: pointer;
+  transition: transform 0.1s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+body.landing-active .hero-settings__theme-btn:hover {
+  transform: translateY(-1px);
+  border-color: rgba(241, 212, 138, 0.5);
+  background: rgba(20, 40, 68, 0.7);
+}
+
+body.landing-active .hero-settings__theme-btn.is-active {
+  border-color: rgba(134, 243, 196, 0.6);
+  background: rgba(134, 243, 196, 0.18);
+  color: #dfffee;
+}
+
+body.landing-active .hero-settings__theme-btn:focus-visible {
+  outline: 2px solid rgba(134, 243, 196, 0.75);
+  outline-offset: 2px;
+}
+
 body.landing-active .brand {
   font-size: clamp(22px, 2.6vw, 28px);
   font-weight: 800;


### PR DESCRIPTION
## Summary
- replace the landing hero alpha badge with a settings button that opens a popup containing the alpha tag
- add a shared theme helper and wire both the landing settings popup and in-game menu to it for consistent theme toggles
- style the landing settings panel and theme buttons to match the existing landing aesthetic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e55e3acef483258c7ed242cc77b599