### PR TITLE
Fix settings menu layering and card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
       --action-button-bg-active: linear-gradient(135deg, rgba(45, 108, 223, 0.95), rgba(88, 173, 255, 0.95));
       --action-button-text-active: #fff;
       --action-button-shadow-active: 0 6px 16px rgba(45, 108, 223, 0.35);
+      --card-bg: #2a3439;
+      --card-text: #000000;
     }
     body.dark {
       --bg-color: #0c1324;
@@ -36,6 +38,8 @@
       --action-button-bg-active: linear-gradient(135deg, rgba(68, 119, 255, 0.95), rgba(33, 77, 180, 0.96));
       --action-button-text-active: #f6f8ff;
       --action-button-shadow-active: 0 12px 26px rgba(24, 54, 138, 0.7);
+      --card-bg: rgba(24, 38, 70, 0.9);
+      --card-text: var(--text-color);
     }
     * {
       box-sizing: border-box;
@@ -153,7 +157,7 @@
       display: none;
       flex-direction: column;
       gap: 8px;
-      z-index: 1200;
+      z-index: 3200;
     }
     .menu-panel.open {
       display: flex;

--- a/src/gameUI.js
+++ b/src/gameUI.js
@@ -2706,8 +2706,8 @@ function createBuildCard(type, info) {
   card.style.border = '1px solid var(--map-border)';
   card.style.padding = '8px';
   card.style.borderRadius = '6px';
-  card.style.background = 'var(--map-bg)';
-  card.style.color = 'var(--text-color)';
+  card.style.background = 'var(--card-bg, var(--map-bg))';
+  card.style.color = 'var(--card-text, var(--text-color))';
 
   const title = document.createElement('h4');
   title.textContent = `${type.icon ? `${type.icon} ` : ''}${type.name}`;

--- a/src/ui.js
+++ b/src/ui.js
@@ -245,7 +245,10 @@ export function initSetupUI(onStart) {
     });
   }
 
-  onThemeChange(updateLandingThemeButtons, {
+  onThemeChange(() => {
+    updateLandingThemeButtons();
+    applyInverseCardBackgrounds(wrap);
+  }, {
     immediate: true
   });
 
@@ -284,8 +287,20 @@ export function initSetupUI(onStart) {
 
   function applyInverseCardBackgrounds(rootNode) {
     if (!rootNode) return;
+    const cards = rootNode.querySelectorAll('.card');
+    if (!cards.length) return;
+
+    const theme = getTheme();
+    if (theme === 'light') {
+      cards.forEach(card => {
+        card.style.background = 'var(--card-bg)';
+        card.style.color = 'var(--card-text)';
+      });
+      return;
+    }
+
     const parentColorCache = new WeakMap();
-    rootNode.querySelectorAll('.card').forEach(card => {
+    cards.forEach(card => {
       const parent = card.parentElement;
       if (!parent) return;
       let colors = parentColorCache.get(parent);


### PR DESCRIPTION
## Summary
- raise the settings panel stacking context so it appears above other interface elements
- add dedicated card color variables for the light and dark themes and apply them to build cards
- refresh landing cards on theme changes so the new colors are respected in the light theme

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e576d11f908325aea87b34a795d724