### PR TITLE
Refine hero card hero color

### DIFF
--- a/styles/landing.css
+++ b/styles/landing.css
@@ -132,6 +132,11 @@ body.landing-active .hero {
   padding-block: clamp(14px, 2.5vw, 18px);
 }
 
+body.landing-active .card.hero {
+  background: #36454f;
+  color: #c9bab0;
+}
+
 body.landing-active .hero-settings {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
## Summary
- update the landing hero card to use a medium charcoal gray background with contrasting inverse text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e598ecf4f083258955110cdd5d0eca