### PR TITLE
Update hero card dark mode styling

### DIFF
--- a/styles/landing.css
+++ b/styles/landing.css
@@ -133,8 +133,8 @@ body.landing-active .hero {
 }
 
 body.landing-active .card.hero {
-  background: #36454f;
-  color: #c9bab0;
+  background: #636363;
+  color: #f5f5f5;
 }
 
 body.landing-active .hero-settings {


### PR DESCRIPTION
## Summary
- adjust the hero card's dark mode background to #636363 and use a lighter text color for better contrast

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5a2b53cf883258a49cafae5427101