### PR TITLE
Fix landing settings popover clipping

### DIFF
--- a/styles/landing.css
+++ b/styles/landing.css
@@ -91,7 +91,7 @@ body.landing-active .setup {
   box-shadow: var(--shadow);
   backdrop-filter: blur(var(--blur));
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 
 body.landing-active .setup > * {


### PR DESCRIPTION
## Summary
- allow the landing page settings popover to render above neighboring cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c0472b748325b9d0dc5152c60983