### PR TITLE
Auto-detect theme preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,24 @@
   <link rel="stylesheet" href="styles/landing.css" id="landing-theme">
   <style>
     :root {
+      --bg-color: #0c1324;
+      --text-color: #f1f4ff;
+      --menu-bg: rgba(16, 24, 44, 0.94);
+      --map-bg: #101b33;
+      --map-border: rgba(82, 114, 204, 0.55);
+      --action-panel-bg: rgba(16, 27, 53, 0.95);
+      --action-option-bg: rgba(24, 38, 70, 0.9);
+      --action-button-bg: linear-gradient(135deg, rgba(26, 43, 86, 0.96), rgba(44, 74, 146, 0.92));
+      --action-button-text: var(--text-color);
+      --action-button-shadow: 0 3px 12px rgba(6, 12, 32, 0.55);
+      --action-button-shadow-hover: 0 10px 24px rgba(8, 20, 48, 0.65);
+      --action-button-bg-active: linear-gradient(135deg, rgba(68, 119, 255, 0.95), rgba(33, 77, 180, 0.96));
+      --action-button-text-active: #f6f8ff;
+      --action-button-shadow-active: 0 12px 26px rgba(24, 54, 138, 0.7);
+      --card-bg: rgba(24, 38, 70, 0.9);
+      --card-text: var(--text-color);
+    }
+    body.light {
       --bg-color: #fff;
       --text-color: #000;
       --menu-bg: #eee;
@@ -267,7 +285,39 @@
     }
   </style>
 </head>
-<body class="light">
+<body>
+  <script>
+    (function () {
+      const THEME_STORAGE_KEY = 'theme';
+      const VALID_THEMES = new Set(['light', 'dark']);
+      let preferredTheme = null;
+      try {
+        const stored = localStorage.getItem(THEME_STORAGE_KEY);
+        if (stored && VALID_THEMES.has(stored)) {
+          preferredTheme = stored;
+        }
+      } catch (error) {
+        console.warn('Unable to access theme preference storage during initial load.', error);
+      }
+      if (!preferredTheme) {
+        try {
+          const query = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+            ? window.matchMedia('(prefers-color-scheme: dark)')
+            : null;
+          if (query && typeof query.matches === 'boolean') {
+            preferredTheme = query.matches ? 'dark' : 'light';
+          }
+        } catch (error) {
+          console.warn('Unable to detect system color scheme during initial load.', error);
+        }
+      }
+      if (!preferredTheme) {
+        preferredTheme = 'dark';
+      }
+      document.body.classList.remove('light', 'dark');
+      document.body.classList.add(preferredTheme);
+    })();
+  </script>
   <div id="top-menu"></div>
   <div id="content">
     <div id="setup"></div>

--- a/src/theme.js
+++ b/src/theme.js
@@ -2,17 +2,90 @@ const THEME_STORAGE_KEY = 'theme';
 const VALID_THEMES = new Set(['light', 'dark']);
 const listeners = new Set();
 
+let hasStoredPreference = false;
+let systemPreferenceQuery = null;
+let systemPreferenceListener = null;
+
+function resolveSystemPreferenceQuery() {
+  if (systemPreferenceQuery || typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return systemPreferenceQuery;
+  }
+  try {
+    systemPreferenceQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  } catch (error) {
+    console.warn('Unable to access system color scheme.', error);
+    systemPreferenceQuery = null;
+  }
+  return systemPreferenceQuery;
+}
+
+function detectPreferredTheme() {
+  const query = resolveSystemPreferenceQuery();
+  if (query && typeof query.matches === 'boolean') {
+    return query.matches ? 'dark' : 'light';
+  }
+  return 'dark';
+}
+
 let currentTheme = (() => {
   try {
     const stored = localStorage.getItem(THEME_STORAGE_KEY);
     if (stored && VALID_THEMES.has(stored)) {
+      hasStoredPreference = true;
       return stored;
     }
   } catch (error) {
     console.warn('Unable to access theme preference storage.', error);
   }
-  return 'light';
+  return detectPreferredTheme();
 })();
+
+function updateTheme(nextTheme, { persist = true } = {}) {
+  if (!VALID_THEMES.has(nextTheme)) return;
+
+  if (persist) {
+    hasStoredPreference = true;
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    } catch (error) {
+      console.warn('Unable to persist theme preference.', error);
+    }
+  }
+
+  currentTheme = nextTheme;
+  applyThemeClass();
+  notifyListeners();
+}
+
+function setupSystemPreferenceListener() {
+  const query = resolveSystemPreferenceQuery();
+  if (!query || systemPreferenceListener) {
+    return;
+  }
+
+  const handleChange = event => {
+    if (hasStoredPreference) {
+      return;
+    }
+    const matches = typeof event?.matches === 'boolean' ? event.matches : !!query.matches;
+    const nextTheme = matches ? 'dark' : 'light';
+    updateTheme(nextTheme, { persist: false });
+  };
+
+  if (typeof query.addEventListener === 'function') {
+    query.addEventListener('change', handleChange);
+    systemPreferenceListener = () => {
+      query.removeEventListener('change', handleChange);
+      systemPreferenceListener = null;
+    };
+  } else if (typeof query.addListener === 'function') {
+    query.addListener(handleChange);
+    systemPreferenceListener = () => {
+      query.removeListener(handleChange);
+      systemPreferenceListener = null;
+    };
+  }
+}
 
 function applyThemeClass() {
   if (typeof document === 'undefined' || !document.body) return;
@@ -33,6 +106,7 @@ function notifyListeners() {
 export function initTheme() {
   applyThemeClass();
   notifyListeners();
+  setupSystemPreferenceListener();
 }
 
 export function getTheme() {
@@ -41,19 +115,7 @@ export function getTheme() {
 
 export function setTheme(nextTheme) {
   if (!VALID_THEMES.has(nextTheme)) return;
-  if (nextTheme === currentTheme) {
-    applyThemeClass();
-    notifyListeners();
-    return;
-  }
-  currentTheme = nextTheme;
-  try {
-    localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
-  } catch (error) {
-    console.warn('Unable to persist theme preference.', error);
-  }
-  applyThemeClass();
-  notifyListeners();
+  updateTheme(nextTheme, { persist: true });
 }
 
 export function onThemeChange(listener, { immediate = false } = {}) {


### PR DESCRIPTION
## Summary
- detect the user's preferred color scheme and switch themes automatically when the system setting changes
- default to the dark theme when no preference is available and apply the chosen theme as early as possible during page load

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5c29a6ed883258d8f836974278a73