### PR TITLE
Fix hero settings panel layering

### DIFF
--- a/styles/landing.css
+++ b/styles/landing.css
@@ -135,6 +135,7 @@ body.landing-active .hero {
 body.landing-active .card.hero {
   background: #636363;
   color: #f5f5f5;
+  z-index: 2;
 }
 
 body.landing-active .hero-settings {


### PR DESCRIPTION
## Summary
- raise the hero card's stacking order so its settings panel can layer over the biome card

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e5c5f20a848325828f441d6656c61f