### PR TITLE
Restyle accent elements with solid gray

### DIFF
--- a/styles/landing.css
+++ b/styles/landing.css
@@ -33,8 +33,8 @@
 
   --border-primary: rgba(53, 82, 132, 0.42);
   --border-secondary: rgba(38, 56, 80, 0.6);
-  --border-accent: rgba(241, 212, 138, 0.45);
-  --accent-glow-soft: rgba(241, 212, 138, 0.12);
+  --border-accent: #7d7f81;
+  --accent-glow-soft: #7d7f81;
 
   --ok: var(--color-secondary-accent);
   --warn: #ffd77e;
@@ -144,9 +144,9 @@ body.landing-active .hero-settings {
 }
 
 body.landing-active .hero-settings__trigger {
-  border: 1px solid rgba(241, 212, 138, 0.35);
-  background: rgba(241, 212, 138, 0.12);
-  color: var(--accent-bright);
+  border: 1px solid #7d7f81;
+  background: #7d7f81;
+  color: #ffffff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -161,8 +161,8 @@ body.landing-active .hero-settings__trigger {
 
 body.landing-active .hero-settings__trigger:hover {
   transform: translateY(-1px);
-  background: rgba(241, 212, 138, 0.18);
-  border-color: rgba(241, 212, 138, 0.5);
+  background: #6f7173;
+  border-color: #6f7173;
 }
 
 body.landing-active .hero-settings__trigger:focus-visible {
@@ -231,9 +231,9 @@ body.landing-active .hero-settings__theme-btn {
   gap: 6px;
   padding: 8px 10px;
   border-radius: 12px;
-  border: 1px solid rgba(241, 212, 138, 0.25);
-  background: rgba(15, 28, 46, 0.6);
-  color: var(--text-strong);
+  border: 1px solid #7d7f81;
+  background: #7d7f81;
+  color: #ffffff;
   font-size: 13px;
   cursor: pointer;
   transition: transform 0.1s ease, border-color 0.2s ease, background 0.2s ease;
@@ -241,14 +241,14 @@ body.landing-active .hero-settings__theme-btn {
 
 body.landing-active .hero-settings__theme-btn:hover {
   transform: translateY(-1px);
-  border-color: rgba(241, 212, 138, 0.5);
-  background: rgba(20, 40, 68, 0.7);
+  border-color: #6f7173;
+  background: #6f7173;
 }
 
 body.landing-active .hero-settings__theme-btn.is-active {
-  border-color: rgba(134, 243, 196, 0.6);
-  background: rgba(134, 243, 196, 0.18);
-  color: #dfffee;
+  border-color: #606264;
+  background: #606264;
+  color: #ffffff;
 }
 
 body.landing-active .hero-settings__theme-btn:focus-visible {
@@ -283,9 +283,9 @@ body.landing-active .badge {
   padding: 5px 10px;
   border-radius: 999px;
   font-size: 11px;
-  border: 1px solid rgba(241, 212, 138, 0.3);
-  color: var(--accent-bright);
-  background: rgba(241, 212, 138, 0.12);
+  border: 1px solid #7d7f81;
+  color: #ffffff;
+  background: #7d7f81;
   text-transform: uppercase;
   letter-spacing: 0.8px;
 }
@@ -324,14 +324,14 @@ body.landing-active .seg {
 }
 
 body.landing-active .seg:hover {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
+  border-color: #7d7f81;
+  box-shadow: 0 0 0 1px #7d7f81;
 }
 
 body.landing-active .seg.is-active {
   background: rgba(20, 48, 96, 0.72);
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(241, 212, 138, 0.28);
+  border-color: #7d7f81;
+  box-shadow: 0 0 0 3px #7d7f81;
 }
 
 body.landing-active .seg .hint {
@@ -427,8 +427,8 @@ body.landing-active .input {
 }
 
 body.landing-active .input:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(241, 212, 138, 0.3);
+  border-color: #7d7f81;
+  box-shadow: 0 0 0 3px #7d7f81;
 }
 
 body.landing-active .btn {
@@ -449,7 +449,7 @@ body.landing-active .btn:hover {
 }
 
 body.landing-active .btn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid #7d7f81;
   outline-offset: 3px;
 }
 
@@ -459,9 +459,9 @@ body.landing-active .btn--ghost {
 }
 
 body.landing-active .btn--primary {
-  background: linear-gradient(155deg, rgba(241, 212, 138, 0.9), rgba(241, 212, 138, 0.68));
-  border-color: var(--border-bright);
-  color: #11131a;
+  background: #7d7f81;
+  border-color: #7d7f81;
+  color: #ffffff;
 }
 
 body.landing-active .btn--ok {
@@ -552,12 +552,12 @@ body.landing-active .spawn-confirm button {
 }
 
 body.landing-active .spawn-confirm button:hover {
-  border-color: var(--accent);
+  border-color: #7d7f81;
   transform: translateY(-1px);
 }
 
 body.landing-active .map-marker--spawn {
-  filter: drop-shadow(0 0 8px rgba(241, 212, 138, 0.85));
+  filter: drop-shadow(0 0 8px #7d7f81);
 }
 
 body.landing-active .map-legend {


### PR DESCRIPTION
## Summary
- swap the previous semi-transparent beige accents for solid #7d7f81 backgrounds on hero controls, badges, and primary buttons
- align hover, focus, and highlight treatments with the new gray palette and enforce white text and shadows without transparency

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c7e089388325a9e7995ce37c3686