### PR TITLE
Fix season icon button padding

### DIFF
--- a/styles/landing.css
+++ b/styles/landing.css
@@ -1160,6 +1160,7 @@ body.landing-active .season-switch {
   flex-wrap: wrap;
   gap: 10px;
   justify-content: center;
+  align-items: center;
 }
 
 body.landing-active .season-switch__button {
@@ -1213,8 +1214,8 @@ body.landing-active .season-switch__button--icon {
   justify-content: center;
   gap: 0;
   width: 56px;
-  height: 56px;
-  padding: 6px;
+  min-height: 56px;
+  padding: 10px 8px;
   font-size: clamp(22px, 2.4vw, 30px);
   line-height: 1.1;
   border-radius: 16px;


### PR DESCRIPTION
## Summary
- center the starting season switch icons within their container
- increase icon button padding to prevent active glow from being clipped

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69377256b0c48325924b6d1037c9bd5e)